### PR TITLE
feat: GlobalPortal 구현 및 modal 재사용 컴포넌트 구현

### DIFF
--- a/src/GlobalPortal.jsx
+++ b/src/GlobalPortal.jsx
@@ -1,0 +1,23 @@
+import { createContext, useState } from "react";
+
+export const PortalContext = createContext(null);
+
+const GlobalPortal = ({ children }) => {
+  const [portalContainer, setPortalContext] = useState(null);
+
+  return (
+    <PortalContext.Provider value={portalContainer}>
+      {children}
+      <div
+        ref={(elem) => {
+          if (portalContainer !== null || elem === null) {
+            return null;
+          }
+          setPortalContext(elem);
+        }}
+      />
+    </PortalContext.Provider>
+  );
+};
+
+export default GlobalPortal;

--- a/src/components/ModalOverlay/ModalOverlay.jsx
+++ b/src/components/ModalOverlay/ModalOverlay.jsx
@@ -1,0 +1,35 @@
+import { useContext, useRef } from "react";
+import { createPortal } from "react-dom";
+
+import { PortalContext } from "@/GlobalPortal";
+import useOnClickOutSide from "@/hooks/useOnClickOutSide";
+
+const ModalOverlay = ({ closeModal, children }) => {
+  const modalRef = useRef(null);
+  const portalContainer = useContext(PortalContext);
+
+  useOnClickOutSide(modalRef, closeModal);
+
+  return (
+    portalContainer
+    && createPortal(
+      <div className="fixed top-0 left-0 w-full h-full bg-black/50 flex justify-center items-center">
+        <div
+          ref={modalRef}
+          className="bg-white p-5 rounded-lg shadow"
+        >
+          <button
+            onClick={closeModal}
+            className="ml-auto block"
+          >
+            X
+          </button>
+          {children}
+        </div>
+      </div>,
+      portalContainer,
+    )
+  );
+};
+
+export default ModalOverlay;

--- a/src/hooks/useOnClickOutSide.jsx
+++ b/src/hooks/useOnClickOutSide.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+const useOnClickOutSide = (ref, onClickOutSide) => {
+  useEffect(() => {
+    const handleClose = (event) => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      onClickOutSide();
+    };
+
+    document.addEventListener("mousedown", handleClose);
+
+    return () => document.removeEventListener("mousedown", handleClose);
+  }, [ref, onClickOutSide]);
+};
+
+export default useOnClickOutSide;

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+html, body {
+  height: 100vh;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,12 +3,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-import routes from "./routers/routes";
+import GlobalPortal from "@/GlobalPortal";
+import routes from "@/routers/routes";
 
 const root = document.getElementById("root");
 
 createRoot(root).render(
   <StrictMode>
-    <RouterProvider router={routes} />
+    <GlobalPortal>
+      <RouterProvider router={routes} />
+    </GlobalPortal>
   </StrictMode>,
 );


### PR DESCRIPTION
## #️⃣ Issue Number #3 

</br>

## 📝 요약(Summary)
- PortalContext를 정의하고 GlobalPortal 컴포넌트를 통해 포털 DOM 요소를 전역으로 관리할 수 있도록 구현했습니다.
- ModalOverlay 컴포넌트를 추가하여, 포탈 기반의 모달 UI를 구성하고 외부 클릭 시 닫히도록 커스텀 훅(useOnClickOutSide)을 적용했습니다.
- 모달 내부에 ref를 연결해 클릭 감지 기능이 정상 작동하도록 처리했습니다.

</br>

## 💬 공유사항 to 리뷰어
- useOnClickOutSide 훅과 GlobalPortal 내부 로직 확인 부탁드립니다.

</br>

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.