### PR TITLE
Feat: GlobalPortal 구현 및 modal 재사용 컴포넌트 구현 (#6)

### DIFF
--- a/src/GlobalPortal.jsx
+++ b/src/GlobalPortal.jsx
@@ -1,0 +1,23 @@
+import { createContext, useState } from "react";
+
+export const PortalContext = createContext(null);
+
+const GlobalPortal = ({ children }) => {
+  const [portalContainer, setPortalContext] = useState(null);
+
+  return (
+    <PortalContext.Provider value={portalContainer}>
+      {children}
+      <div
+        ref={(elem) => {
+          if (portalContainer !== null || elem === null) {
+            return null;
+          }
+          setPortalContext(elem);
+        }}
+      />
+    </PortalContext.Provider>
+  );
+};
+
+export default GlobalPortal;

--- a/src/components/ModalOverlay/ModalOverlay.jsx
+++ b/src/components/ModalOverlay/ModalOverlay.jsx
@@ -1,0 +1,35 @@
+import { useContext, useRef } from "react";
+import { createPortal } from "react-dom";
+
+import { PortalContext } from "@/GlobalPortal";
+import useOnClickOutSide from "@/hooks/useOnClickOutSide";
+
+const ModalOverlay = ({ closeModal, children }) => {
+  const modalRef = useRef(null);
+  const portalContainer = useContext(PortalContext);
+
+  useOnClickOutSide(modalRef, closeModal);
+
+  return (
+    portalContainer
+    && createPortal(
+      <div className="fixed top-0 left-0 w-full h-full bg-black/50 flex justify-center items-center">
+        <div
+          ref={modalRef}
+          className="bg-white p-5 rounded-lg shadow"
+        >
+          <button
+            onClick={closeModal}
+            className="ml-auto block"
+          >
+            X
+          </button>
+          {children}
+        </div>
+      </div>,
+      portalContainer,
+    )
+  );
+};
+
+export default ModalOverlay;

--- a/src/hooks/useOnClickOutSide.jsx
+++ b/src/hooks/useOnClickOutSide.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+const useOnClickOutSide = (ref, onClickOutSide) => {
+  useEffect(() => {
+    const handleClose = (event) => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      onClickOutSide();
+    };
+
+    document.addEventListener("mousedown", handleClose);
+
+    return () => document.removeEventListener("mousedown", handleClose);
+  }, [ref, onClickOutSide]);
+};
+
+export default useOnClickOutSide;

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+html, body {
+  height: 100vh;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,12 +3,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
-import routes from "./routers/routes";
+import GlobalPortal from "@/GlobalPortal";
+import routes from "@/routers/routes";
 
 const root = document.getElementById("root");
 
 createRoot(root).render(
   <StrictMode>
-    <RouterProvider router={routes} />
+    <GlobalPortal>
+      <RouterProvider router={routes} />
+    </GlobalPortal>
   </StrictMode>,
 );


### PR DESCRIPTION
- html, body 요소가 화면 전체 높이를 차지하도록 설정
- PortalContext 정의 및 GlobalPortal 컴포넌트로 앱 전체 구조를 감싸도록 설정
- feat: 외부 영역 클릭 감지용 useOnClickOutSide 커스텀 훅 추가
- 포탈 기반의 모달 오버레이 컴포넌트 구현