### PR TITLE
Refactor: game page canvas UI split

### DIFF
--- a/src/components/CameraControls/CameraControls.jsx
+++ b/src/components/CameraControls/CameraControls.jsx
@@ -1,8 +1,9 @@
+import { OrbitControls } from "@react-three/drei";
 import { useThree, useFrame } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
 import * as THREE from "three";
 
-const useCameraControls = () => {
+const useCameraControls = ({ rotationSensitivity }) => {
   const { camera } = useThree();
   const speed = 0.1;
   const keys = useRef({});
@@ -32,6 +33,14 @@ const useCameraControls = () => {
     if (keys.current["a"]) camera.position.addScaledVector(right, -speed);
     if (keys.current["d"]) camera.position.addScaledVector(right, speed);
   });
+
+  return (
+    <OrbitControls
+      enableZoom={true}
+      mouseButtons={{ LEFT: null, MIDDLE: 0, RIGHT: null }}
+      rotateSpeed={rotationSensitivity}
+    />
+  );
 };
 
 export default useCameraControls;

--- a/src/components/DominoCanvas/DominoCanvas.jsx
+++ b/src/components/DominoCanvas/DominoCanvas.jsx
@@ -1,0 +1,22 @@
+import { Canvas } from "@react-three/fiber";
+
+import CameraControls from "@/components/CameraControls/CameraControls";
+
+const DominoCanvas = ({ rotationSensitivity, children }) => {
+  return (
+    <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
+      <ambientLight
+        intensity={0.5}
+        color="white"
+      />
+      <directionalLight
+        castShadow
+        position={[5, 10, 5]}
+      />
+      <CameraControls rotationSensitivity={rotationSensitivity} />
+      {children}
+    </Canvas>
+  );
+};
+
+export default DominoCanvas;

--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,0 +1,18 @@
+const DominoHUD = ({ rotationSensitivity, onChangeSensitivity }) => {
+  return (
+    <div className="fixed z-50">
+      <input
+        id="sensitivity"
+        type="range"
+        min={1}
+        max={50}
+        step={0.01}
+        value={rotationSensitivity}
+        onChange={onChangeSensitivity}
+        className="w-full"
+      />
+    </div>
+  );
+};
+
+export default DominoHUD;

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -1,8 +1,7 @@
-import { RoundedBox, Sky, OrbitControls } from "@react-three/drei";
-import { Canvas } from "@react-three/fiber";
 import { useState } from "react";
 
-import CameraControls from "@/components/CameraControls/CameraControls";
+import DominoCanvas from "@/components/DominoCanvas/DominoCanvas";
+import DominoHUD from "@/components/DominoHUD/DominoHUD";
 
 const DominoScene = () => {
   const [rotationSensitivity, setRotationSensitivity] = useState(1);
@@ -13,48 +12,16 @@ const DominoScene = () => {
 
   return (
     <>
-      <input
-        id="sensitivity"
-        type="range"
-        min={1}
-        max={50}
-        step={0.01}
-        value={rotationSensitivity}
-        onChange={handleRotationSensitivity}
-        className="w-full"
+      <DominoHUD
+        rotationSensitivity={rotationSensitivity}
+        onChangeSensitivity={handleRotationSensitivity}
       />
-      <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
-        <ambientLight
-          intensity={0.5}
-          color="white"
-        />
-        <directionalLight
-          castShadow
-          position={[5, 10, 5]}
-        />
-        {/* Sky 컴포넌트가 렌더링 성능에 영향을 줘 일시적으로 비활성화함 (최적화 후 재사용 예정) */}
-        {/* <Sky
-          distance={450000}
-          sunPosition={[0, 1, 0]}
-          inclination={0}
-          azimuth={0.25}
-        /> */}
-        <CameraControls />
-        <OrbitControls
-          enableZoom={true}
-          mouseButtons={{ LEFT: null, MIDDLE: 0, RIGHT: null }}
-          rotateSpeed={rotationSensitivity}
-        />
-
-        <RoundedBox>
-          <meshStandardMaterial color="orange" />
-        </RoundedBox>
-
+      <DominoCanvas rotationSensitivity={rotationSensitivity}>
         <mesh position={[2, 2, 2]}>
           <boxGeometry />
           <meshStandardMaterial color="orange" />
         </mesh>
-      </Canvas>
+      </DominoCanvas>
     </>
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number #12 

## 📝 요약(Summary)
- 기존 DominoScene의 UI 및 3D 캔버스 로직 컴포넌트 분리
- DominoHUD: HUD 인터페이스 전용 컴포넌트로 분리 (input range)
- DominoCanvas: 3D 렌더링 전용 컴포넌트로 분리
- 상태(rotationSensitivity)를 상위 컴포넌트에서 관리하고 props로 전달
- 추후 컴포넌트 단위 테스트 및 리팩토링 기반 구조 확보

## 💬 공유사항 to 리뷰어
- game page의 책임 분리를 통해 UI와 로직을 명확히 분리하고 유지보수성과 확장성을 확보하기 위한 리팩토링 작업을 진행하였습니다.
- 기존에 하나의 컴포넌트에 포함되어 있던 UI 요소(input range)와 3D 렌더링 로직(Canvas)을 각각 DominoHUD, DominoCanvas로 분리하여 역할을 명확히 하였습니다.
- 이후 HUD 기능 추가나 캔버스 제어 고도화 작업이 용이하도록 구조화하였습니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.