### PR TITLE
Fix: 단축키 입력 시 선택된 오브젝트가 아닌 전체 오브젝트가 영향 받는 버그 해결

### DIFF
--- a/src/constants/mode.js
+++ b/src/constants/mode.js
@@ -1,0 +1,8 @@
+const MODE = {
+  EDIT: "EDIT",
+  READY: "READY",
+  COUNTDOWN: "COUNTDOWN",
+  SIMULATING: "SIMULATING",
+  END: "END",
+};
+export default MODE;

--- a/src/constants/mode.js
+++ b/src/constants/mode.js
@@ -5,4 +5,5 @@ const MODE = {
   SIMULATING: "SIMULATING",
   END: "END",
 };
+
 export default MODE;

--- a/src/hooks/useDominoControls.jsx
+++ b/src/hooks/useDominoControls.jsx
@@ -9,7 +9,7 @@ const useDominoControls = ({ onToggleGuideToast }) => {
     const pressX = (e) => {
       if (e.key.toLowerCase() === "x") {
         const updateDominos = [...dominos];
-        setDominos(updateDominos.filter((dominos) => dominos.index !== selectedDominoKey));
+        setDominos(updateDominos.filter((dominos) => dominos.id !== selectedDominoKey));
         setTimeout(() => {
           onToggleGuideToast(false);
         }, 100);
@@ -19,7 +19,7 @@ const useDominoControls = ({ onToggleGuideToast }) => {
     const pressH = (e) => {
       if (e.key.toLowerCase() === "h") {
         const updatedDominos = dominos.map((item) => {
-          if (item.index === selectedDominoKey) {
+          if (item.id === selectedDominoKey) {
             const isTransparent = item.opacity < 1;
             return { ...item, opacity: isTransparent ? 1 : 0.3 };
           }

--- a/src/hooks/useToastControls.jsx
+++ b/src/hooks/useToastControls.jsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
 
-import useDominoStore from "../store/useDominoStore";
+import MODE from "@/constants/mode";
+import useDominoStore from "@/store/useDominoStore";
+import useSimulationStore from "@/store/useSimulationStore";
 
 const useToastControls = () => {
   const [isOpenGuideToastVisible, setIsGuideToastVisible] = useState(false);
   const setSelectedDominoKey = useDominoStore((state) => state.setSelectedDominoKey);
+  const { simulationMode } = useSimulationStore();
+
   const openGuideToast = (key) => {
-    setIsGuideToastVisible(true);
-    setSelectedDominoKey(key);
+    if (simulationMode === MODE.EDIT) {
+      setIsGuideToastVisible(true);
+      setSelectedDominoKey(key);
+    }
   };
 
   const closeGuideToast = () => {

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -48,7 +48,8 @@ const DominoScene = () => {
               <ObjectRenderer
                 dominoInfo={domino.objectInfo}
                 position={domino.position}
-                onPointerOver={() => openGuideToast(domino.index)}
+                key={domino.id}
+                onPointerOver={() => openGuideToast(domino.id)}
                 onPointerOut={closeGuideToast}
                 onClick={(event) => readyDominoSimulation(event, index)}
                 opacity={domino.opacity}


### PR DESCRIPTION
## #️⃣ Issue Number #29

## 📝 요약(Summary)
단축키 입력 시 현재 마우스 호버 중인 오브젝트에만 반응해야 하는 로직에서, 전체 도미노 오브젝트가 동시에 반응하는 문제가 있었습니다.

**해결**
• 기존에는 selectedDomino를 인덱스로 관리하면서,오브젝트의 고유 식별이 제대로 되지 않았습니다.
•  Date.now()를 활용하여  각 도미노 오브젝트에 고유 키값을 부여하고, 이를 기준으로 호버 및 단축키 이벤트를 처리하도록 수정하였습니다.

## 📸 스크린샷
![PR에 올릴 영상](https://github.com/user-attachments/assets/6ff95ccb-c116-40c8-bc21-5c6e2ded5137)


## 💬 공유사항 to 리뷰어
•	기존에는 인덱스를 기준으로 오브젝트를 추적했기 때문에, 배열이 변경되거나 재정렬되는 경우 잘못된 오브젝트에 이벤트가  
         발생할 수 있었습니다.
•	id를 기반으로 처리하도록 변경하면서 보다 안정적인 이벤트 타겟팅이 가능해졌습니다.


## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.