### PR TITLE
Feat: 커서 도미노가 바닥 또는 다른 도미노 위에 정확히 올라가도록 위치 보정

### DIFF
--- a/src/components/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/CursorFollowerObject/CursorFollowerObject.jsx
@@ -1,35 +1,65 @@
 import { useFrame, useThree } from "@react-three/fiber";
-import { useState } from "react";
+import { useRef } from "react";
 import * as THREE from "three";
 
 import ObjectRenderer from "@/components/ObjectRenderer/ObjectRenderer";
 import useDominoStore from "@/store/useDominoStore";
 
+const DOMINO_HEIGHT = 1;
+const HALF_DOMINO_HEIGHT = DOMINO_HEIGHT / 2;
+const DEFAULT_OPACITY = 1;
+const BLOCKED_MOUSE_BUTTONS = [1, 2];
+
 const CursorFollowerObject = () => {
-  const [position, setPosition] = useState({ x: 0, y: 0, z: 0 });
-  const selectedDomino = useDominoStore((state) => state.selectedDomino);
+  const { dominos, setDominos, selectedDomino } = useDominoStore();
   const { camera, pointer, scene } = useThree();
+  const meshRef = useRef();
+
+  const handlePlaceDomino = (e) => {
+    e.stopPropagation();
+    const isBlockedClick = BLOCKED_MOUSE_BUTTONS.includes(e.button);
+    if (isBlockedClick || !selectedDomino || !meshRef.current) return;
+
+    const currentPosition = meshRef.current.position;
+
+    const newDomino = {
+      id: Date.now(),
+      position: [currentPosition.x, currentPosition.y, currentPosition.z],
+      objectInfo: selectedDomino,
+      opacity: DEFAULT_OPACITY,
+    };
+    setDominos([...dominos, newDomino]);
+  };
 
   useFrame(() => {
     const raycaster = new THREE.Raycaster();
     raycaster.setFromCamera(pointer, camera);
 
     const ground = scene.getObjectByName("ground");
-    if (!ground) return;
+    const allDominoes = scene.children.filter((child) => child.name === "domino");
 
-    const intersects = raycaster.intersectObject(ground);
-    const isOnGround = intersects[0];
+    if (!ground || !meshRef.current) return;
 
-    if (isOnGround) {
-      const pos = isOnGround.point;
-      const newPos = { x: pos.x, y: 0, z: pos.z };
-      setPosition(newPos);
-    }
+    const intersects = raycaster.intersectObjects([ground, ...allDominoes], true);
+    const [firstHit] = intersects;
+
+    if (!firstHit) return;
+
+    const pos = firstHit.point;
+    const objectHit = firstHit.object;
+
+    const bbox = new THREE.Box3().setFromObject(objectHit);
+    const y = bbox.max.y + HALF_DOMINO_HEIGHT;
+
+    meshRef.current.position.set(pos.x, y, pos.z);
   });
 
   return (
     selectedDomino !== null && (
-      <mesh position={[position.x, position.y, position.z]}>
+      <mesh
+        ref={meshRef}
+        onPointerDown={handlePlaceDomino}
+      >
         <ObjectRenderer dominoInfo={selectedDomino} />
       </mesh>
     )

--- a/src/components/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/CursorFollowerObject/CursorFollowerObject.jsx
@@ -17,8 +17,11 @@ const CursorFollowerObject = () => {
 
   const handlePlaceDomino = (e) => {
     e.stopPropagation();
+
     const isBlockedClick = BLOCKED_MOUSE_BUTTONS.includes(e.button);
-    if (isBlockedClick || !selectedDomino || !meshRef.current) return;
+    const cannotPlaceDomino = isBlockedClick || !selectedDomino || !meshRef.current;
+
+    if (cannotPlaceDomino) return;
 
     const currentPosition = meshRef.current.position;
 

--- a/src/components/Ground/Ground.jsx
+++ b/src/components/Ground/Ground.jsx
@@ -3,32 +3,16 @@ import { RigidBody } from "@react-three/rapier";
 import * as THREE from "three";
 import { TextureLoader } from "three";
 
-import useDominoStore from "@/store/useDominoStore";
 import useSettingStore from "@/store/useSettingStore";
 
 const Ground = () => {
   const groundType = useSettingStore((state) => state.groundType);
-  const { dominos, setDominos, selectedDomino } = useDominoStore();
 
   const floorTexture = useLoader(TextureLoader, `/images/tile/${groundType}.png`);
 
   floorTexture.wrapS = THREE.RepeatWrapping;
   floorTexture.wrapT = THREE.RepeatWrapping;
   floorTexture.repeat.set(10, 10);
-
-  const handlePlaceDomino = (e) => {
-    const isNotLeftClick = e.button === 1 || e.button === 2;
-    if (isNotLeftClick || !selectedDomino) return;
-
-    const pos = e.point;
-    const newDomino = {
-      id: Date.now(),
-      position: [pos.x, 0, pos.z],
-      objectInfo: selectedDomino,
-      opacity: 1,
-    };
-    setDominos([...dominos, newDomino]);
-  };
 
   return (
     <RigidBody
@@ -39,7 +23,6 @@ const Ground = () => {
         name="ground"
         receiveShadow
         position={[0, -1, 0]}
-        onPointerDown={handlePlaceDomino}
       >
         <boxGeometry args={[40, 1, 40]} />
         <meshStandardMaterial

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -31,6 +31,7 @@ const DominoScene = () => {
         {dominos.length
           && dominos.map((domino, index) => (
             <RigidBody
+              name="domino"
               key={domino.id}
               restitution={0}
               friction={1}


### PR DESCRIPTION
[FEATURE]  커서 도미노가 바닥 또는 다른 도미노 위에 정확히 위치하도록 위치 보정 기능 구현 #43

## #️⃣ Issue Number #43 

## 📝 요약(Summary)
- 커서 도미노가 바닥 또는 기존 도미노 위에 정확히 위치하도록 y 좌표를 보정하는 기능을 구현했습니다.
- Raycaster로 감지된 오브젝트의 bounding box를 기준으로 도미노 높이 절반을 더해 중심 정렬되도록 처리했습니다.
- 클릭 시 커서 도미노의 실제 위치(mesh 기준)를 그대로 복제해 정확한 배치 위치를 보장합니다.


## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/e669d30f-12d4-4a3d-a4ae-0ed147c8c93b



## 💬 공유사항 to 리뷰어
- 커서 도미노의 위치 업데이트 시 useState로 상태를 관리하지 않고 meshRef를 직접 조작하는 방식으로 구현하여 렌더링 최적화를 고려했습니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.