### PR TITLE
Fix: 도미노가 클릭 방향과 다른 축으로 회전하던 현상 해결

### DIFF
--- a/src/hooks/useDominoSimulation.jsx
+++ b/src/hooks/useDominoSimulation.jsx
@@ -6,7 +6,7 @@ import MODE from "@/constants/mode";
 import useDominoStore from "@/store/useDominoStore";
 import useSimulationStore from "@/store/useSimulationStore";
 
-const FORCE = 4.5;
+const FORCE = 6;
 
 const useDominoSimulation = () => {
   const { dominos, setSelectedDomino } = useDominoStore();
@@ -50,19 +50,20 @@ const useDominoSimulation = () => {
     const rigidBodyRef = rigidBodyRefs.current[index];
     if (!rigidBodyRef) return;
 
-    const clickedNormal = event.face?.normal.clone().normalize();
+    const clickedNormal = event.face?.normal.clone();
     if (!clickedNormal) return;
 
-    const worldDirection = event.object
-      .localToWorld(clickedNormal.clone())
-      .sub(event.object.position)
-      .normalize();
+    const worldDirection = clickedNormal.clone().transformDirection(event.object.matrixWorld);
+
+    worldDirection.y = 0;
+    worldDirection.normalize();
 
     const fallDirection = worldDirection.clone().multiplyScalar(-1);
     const { x: pushX, z: pushZ } = fallDirection;
 
     const isFallDirectionX = Math.abs(pushX) > Math.abs(pushZ);
     const spinDirection = isFallDirectionX ? -Math.sign(pushX) : -Math.sign(pushZ);
+
     const angularForce = {
       x: isFallDirectionX ? 0 : spinDirection * FORCE,
       y: 0,


### PR DESCRIPTION
## #️⃣ Issue Number #47

## 📝 요약(Summary)
도미노 클릭 시 회전 방향 계산 로직을 개선했습니다.
기존에는 `localToWorld()`를 사용해 방향 벡터를 계산했지만, 이 방식은 위치 정보까지 포함되어 있어 정확하지 않았습니다.
이를 `transformDirection()`으로 교체하여 정확한 월드 방향 벡터를 계산하도록 수정했습니다.
또한 물리적 회전 힘의 크기도 약간 증가시켜 더 자연스럽게 넘어지도록 조정했습니다.

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/745f2ff4-6f5a-4a61-be08-c0640a9148b0


## 💬 공유사항 to 리뷰어
- `transformDirection()`을 사용한 방식이 실제 클릭 방향을 더 정확히 반영한다고 판단했는데,
   혹시 다른 의견이나 개선 포인트가 있을지 궁금합니다.
- FORCE 값을 6으로 조정했는데, 추후 물리 감도에 따라 추가 조정이 필요할 수 있습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.