### PR TITLE
Fix: 배경음 클릭 재생 전환 및 도미노 효과음 볼륨 조절 기능 추가

### DIFF
--- a/src/components/Common/GlobalAudio.jsx
+++ b/src/components/Common/GlobalAudio.jsx
@@ -14,8 +14,16 @@ const GlobalAudio = () => {
   useEffect(() => {
     const audioController = audioControllerRef.current;
     audioController.init(camera, volumeLevel, true);
-    audioController.play(BGM_PATH);
+
+    const handleFirstClick = () => {
+      audioController.play(BGM_PATH);
+      window.removeEventListener("click", handleFirstClick);
+    };
+
+    window.addEventListener("click", handleFirstClick);
+
     return () => {
+      window.removeEventListener("click", handleFirstClick);
       audioController.cleanup(camera);
     };
   }, []);

--- a/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
@@ -4,22 +4,18 @@ import * as THREE from "three";
 
 import { ObjectRenderer } from "@/components/DominoCanvas";
 import useDominoStore from "@/store/useDominoStore";
+import useSettingStore from "@/store/useSettingStore";
 import AudioController from "@/utils/AudioController";
 
-const DOMINO_HEIGHT = 1;
-const HALF_DOMINO_HEIGHT = DOMINO_HEIGHT / 2;
 const DEFAULT_OPACITY = 1;
 const BLOCKED_MOUSE_BUTTONS = [1, 2];
 
 const CursorFollowerObject = () => {
   const { dominos, setDominos, selectedDomino, rotationY, selectedColor } = useDominoStore();
+  const objectVolume = useSettingStore((state) => state.objectVolume);
   const { camera, pointer, scene } = useThree();
   const meshRef = useRef();
   const audioController = useRef(new AudioController());
-
-  useEffect(() => {
-    audioController.current.init(camera, 2, false);
-  }, [camera]);
 
   const playDominoDropSound = () => {
     audioController.current.play(selectedDomino.paths.sound);
@@ -70,6 +66,14 @@ const CursorFollowerObject = () => {
     meshRef.current.position.set(pos.x, y, pos.z);
     meshRef.current.rotation.set(0, rotationY, 0);
   });
+
+  useEffect(() => {
+    audioController.current.init(camera, objectVolume, false);
+
+    if (audioController.current) {
+      audioController.current.setVolume(objectVolume);
+    }
+  }, [camera, objectVolume]);
 
   return (
     selectedDomino !== null && (

--- a/src/components/DominoHUD/SettingModal/SettingModal.jsx
+++ b/src/components/DominoHUD/SettingModal/SettingModal.jsx
@@ -21,6 +21,8 @@ const SettingModal = ({ closeModal }) => {
     setGroundType,
     volumeLevel,
     setVolumeLevel,
+    objectVolume,
+    setObjectVolume,
   } = useSettingStore();
 
   return (
@@ -38,7 +40,7 @@ const SettingModal = ({ closeModal }) => {
             className="w-full mb-[16px] appearance-none h-[8px] rounded bg-gray-200 custom-slider"
           />
         </SettingGroup>
-        <SettingGroup title="음량">
+        <SettingGroup title="배경 음악 음량">
           <input
             id="volume"
             type="range"
@@ -46,6 +48,17 @@ const SettingModal = ({ closeModal }) => {
             step={0.01}
             value={volumeLevel}
             onChange={(e) => setVolumeLevel(parseFloat(e.target.value))}
+            className="w-full mb-[16px] appearance-none h-[8px] rounded bg-gray-100 custom-slider"
+          />
+        </SettingGroup>
+        <SettingGroup title="효과음 음량">
+          <input
+            id="object-volume"
+            type="range"
+            max={4}
+            step={0.01}
+            value={objectVolume}
+            onChange={(e) => setObjectVolume(parseFloat(e.target.value))}
             className="w-full mb-[16px] appearance-none h-[8px] rounded bg-gray-100 custom-slider"
           />
         </SettingGroup>

--- a/src/store/useSettingStore.jsx
+++ b/src/store/useSettingStore.jsx
@@ -4,10 +4,12 @@ const useSettingStore = create((set) => ({
   groundType: "wood_dark",
   rotationSensitivity: 1,
   volumeLevel: 0.5,
+  objectVolume: 3,
 
   setGroundType: (groundType) => set(() => ({ groundType })),
   setRotationSensitivity: (sensitivity) => set(() => ({ rotationSensitivity: sensitivity })),
   setVolumeLevel: (newVolume) => set(() => ({ volumeLevel: newVolume })),
+  setObjectVolume: (newVolume) => set(() => ({ objectVolume: newVolume })),
 }));
 
 export default useSettingStore;


### PR DESCRIPTION
## #️⃣ Issue Number #55 

## 📝 요약(Summary)
- 브라우저의 autoplay 정책으로 인해 배경음(BGM)이 자동 재생되지 않는 문제를 해결하기 위해, 사용자 첫 클릭 시 BGM이 재생되도록 변경했습니다.
- 도미노 배치 시 재생되는 효과음에 대해 개별 볼륨 조절 기능을 구현했습니다.
- 설정 모달에서 슬라이더로 조절 가능
- Zustand 상태를 통해 objectVolume 값 저장 및 반영

## 📸 스크린샷 (선택)

![스크린샷 2025-06-03 오전 12 08 19](https://github.com/user-attachments/assets/3f80d5f5-a3c9-4f61-aeda-d9c47e745886)

## 💬 공유사항 to 리뷰어
- 브라우저의 자동 재생 정책에 따라 오디오는 다음 네 가지 조건 중 하나를 충족해야 재생됩니다:

1. 오디오가 **음소거(muted)** 되었거나 볼륨이 0으로 설정된 경우  
2. 사용자가 **사이트와 상호작용**(클릭, 탭, 키 입력 등)을 한 경우  
3. 사이트가 **허용 목록**에 포함된 경우 (MEI: Media Engagement Index 기반)  
4. `<iframe>`에 대해 **autoplay 권한이 명시적으로 부여된 경우**

- 현재는 **두 번째 방법(사용자 클릭 이후 BGM 재생)**을 적용하여 autoplay 문제를 우회했습니다.  
- 더 적합하거나 안정적인 대안이 있다면 의견 부탁드립니다!

[Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Autoplay)

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.