### PR TITLE
Refactor/frontend cleanup

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/src/components/Common/ModalLayer.jsx
+++ b/src/components/Common/ModalLayer.jsx
@@ -1,0 +1,16 @@
+const ModalLayer = ({ modals }) => {
+  return (
+    <>
+      {modals.map((modal) =>
+        modal.isOpen ?
+          <modal.Component
+            key={modal.key}
+            {...modal.props}
+          />
+        : null,
+      )}
+    </>
+  );
+};
+
+export default ModalLayer;

--- a/src/components/DominoCanvas/CameraControls/CameraControls.jsx
+++ b/src/components/DominoCanvas/CameraControls/CameraControls.jsx
@@ -1,6 +1,10 @@
 import { OrbitControls } from "@react-three/drei";
 
-const CameraControls = ({ rotationSensitivity }) => {
+import useSettingStore from "@/store/useSettingStore";
+
+const CameraControls = () => {
+  const rotationSensitivity = useSettingStore((state) => state.rotationSensitivity);
+
   return (
     <OrbitControls
       enableZoom={true}

--- a/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
@@ -34,7 +34,7 @@ const CursorFollowerObject = () => {
   const audioController = useRef(new AudioController());
 
   const playDominoDropSound = () => {
-    audioController.current.play(selectedDomino.paths.sound);
+    audioController.current.play(selectedDomino.objectInfo.sound);
   };
 
   const handlePlaceDomino = (e) => {
@@ -51,7 +51,7 @@ const CursorFollowerObject = () => {
       id: Date.now(),
       position: [currentPosition.x, currentPosition.y, currentPosition.z],
       rotation: [0, rotationY, 0],
-      objectInfo: selectedDomino,
+      objectMetaData: selectedDomino,
       opacity: DEFAULT_OPACITY,
       color: selectedColor,
     };

--- a/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
@@ -75,11 +75,11 @@ const CursorFollowerObject = () => {
     if (!firstHit) return;
 
     const pos = firstHit.point;
-    const bbox = new THREE.Box3().setFromObject(meshRef.current);
-    const height = bbox.max.y - bbox.min.y;
-    const y = pos.y + height / 2;
+    const boundingBox = new THREE.Box3().setFromObject(meshRef.current);
+    const height = boundingBox.max.y - boundingBox.min.y;
+    const centerY = pos.y + height / 2;
 
-    meshRef.current.position.set(pos.x, y, pos.z);
+    meshRef.current.position.set(pos.x, centerY, pos.z);
     meshRef.current.rotation.set(0, rotationY, 0);
   });
 

--- a/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
@@ -34,7 +34,7 @@ const CursorFollowerObject = () => {
   const audioController = useRef(new AudioController());
 
   const playDominoDropSound = () => {
-    audioController.current.play(selectedDomino.objectInfo.sound);
+    audioController.current.play(selectedDomino.sound);
   };
 
   const handlePlaceDomino = (e) => {
@@ -51,7 +51,7 @@ const CursorFollowerObject = () => {
       id: Date.now(),
       position: [currentPosition.x, currentPosition.y, currentPosition.z],
       rotation: [0, rotationY, 0],
-      objectMetaData: selectedDomino,
+      objectInfo: { ...selectedDomino },
       opacity: DEFAULT_OPACITY,
       color: selectedColor,
     };

--- a/src/components/DominoCanvas/DominoCanvas.jsx
+++ b/src/components/DominoCanvas/DominoCanvas.jsx
@@ -7,12 +7,7 @@ import DominoEntity from "./DominoEntity/DominoEntity";
 
 import GlobalAudio from "@/components/Common/GlobalAudio";
 import Loading from "@/components/Common/Loading";
-import {
-  Ground,
-  CarController,
-  CameraControls,
-  CursorFollowerObject,
-} from "@/components/DominoCanvas";
+import { Ground, CameraControls, CursorFollowerObject } from "@/components/DominoCanvas";
 
 const DominoCanvas = ({
   openGuideToast,
@@ -47,7 +42,6 @@ const DominoCanvas = ({
               readyDominoSimulation={readyDominoSimulation}
               rigidBodyRefs={rigidBodyRefs}
             />
-            <CarController rigidBodyRefs={rigidBodyRefs} />
             <Ground />
           </Physics>
         </Suspense>

--- a/src/components/DominoCanvas/DominoCanvas.jsx
+++ b/src/components/DominoCanvas/DominoCanvas.jsx
@@ -3,11 +3,23 @@ import { Canvas } from "@react-three/fiber";
 import { Physics } from "@react-three/rapier";
 import { Suspense } from "react";
 
+import DominoEntity from "./DominoEntity/DominoEntity";
+
 import GlobalAudio from "@/components/Common/GlobalAudio";
 import Loading from "@/components/Common/Loading";
-import { CameraControls, CursorFollowerObject } from "@/components/DominoCanvas";
+import {
+  Ground,
+  CarController,
+  CameraControls,
+  CursorFollowerObject,
+} from "@/components/DominoCanvas";
 
-const DominoCanvas = ({ children }) => {
+const DominoCanvas = ({
+  openGuideToast,
+  closeGuideToast,
+  readyDominoSimulation,
+  rigidBodyRefs,
+}) => {
   return (
     <>
       <Canvas camera={{ position: [0, 5, 5], fov: 75 }}>
@@ -29,7 +41,14 @@ const DominoCanvas = ({ children }) => {
           <CameraControls />
           <Physics>
             <CursorFollowerObject />
-            {children}
+            <DominoEntity
+              openGuideToast={openGuideToast}
+              closeGuideToast={closeGuideToast}
+              readyDominoSimulation={readyDominoSimulation}
+              rigidBodyRefs={rigidBodyRefs}
+            />
+            <CarController rigidBodyRefs={rigidBodyRefs} />
+            <Ground />
           </Physics>
         </Suspense>
       </Canvas>

--- a/src/components/DominoCanvas/DominoCanvas.jsx
+++ b/src/components/DominoCanvas/DominoCanvas.jsx
@@ -7,7 +7,7 @@ import GlobalAudio from "@/components/Common/GlobalAudio";
 import Loading from "@/components/Common/Loading";
 import { CameraControls, CursorFollowerObject } from "@/components/DominoCanvas";
 
-const DominoCanvas = ({ rotationSensitivity, children }) => {
+const DominoCanvas = ({ children }) => {
   return (
     <>
       <Canvas camera={{ position: [0, 5, 5], fov: 75 }}>
@@ -26,7 +26,7 @@ const DominoCanvas = ({ rotationSensitivity, children }) => {
             preset="park"
             background
           />
-          <CameraControls rotationSensitivity={rotationSensitivity} />
+          <CameraControls />
           <Physics>
             <CursorFollowerObject />
             {children}

--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -16,14 +16,14 @@ const DominoEntity = ({
     <>
       {dominos.length
         && dominos.map((domino, index) => {
-          const { position, rotation, color, opacity, id, objectMetaData } = domino;
-          const { colliders, type } = domino.objectMetaData.objectInfo;
+          const { position, rotation, color, opacity, id, objectInfo } = domino;
+          const { colliders, type, objectName } = objectInfo;
 
           return (
             <RigidBody
               type={type}
               colliders={colliders}
-              name={objectMetaData.objectName}
+              name={objectName}
               key={id}
               restitution={0}
               friction={1}
@@ -34,13 +34,13 @@ const DominoEntity = ({
               ref={(ref) => (rigidBodyRefs.current[index] = ref)}
             >
               <DominoVisualUnit
-                objectName={objectMetaData?.objectName}
+                objectName={objectName}
                 id={id}
                 position={position}
                 rigidBodyRefs={rigidBodyRefs}
               />
               <ObjectRenderer
-                dominoInfo={objectMetaData}
+                dominoInfo={objectInfo}
                 onPointerOver={(event) => openGuideToast(event, id)}
                 onPointerOut={closeGuideToast}
                 onClick={(event) => readyDominoSimulation(event, index)}

--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -16,14 +16,14 @@ const DominoEntity = ({
     <>
       {dominos.length
         && dominos.map((domino, index) => {
-          const { position, rotation, color, opacity, id, objectInfo } = domino;
-          const { colliders, type } = domino.objectInfo.paths;
+          const { position, rotation, color, opacity, id, objectMetaData } = domino;
+          const { colliders, type } = domino.objectMetaData.objectInfo;
 
           return (
             <RigidBody
               type={type}
               colliders={colliders}
-              name={objectInfo.objectName}
+              name={objectMetaData.objectName}
               key={id}
               restitution={0}
               friction={1}
@@ -34,13 +34,13 @@ const DominoEntity = ({
               ref={(ref) => (rigidBodyRefs.current[index] = ref)}
             >
               <DominoVisualUnit
-                objectName={objectInfo?.objectName}
+                objectName={objectMetaData?.objectName}
                 id={id}
                 position={position}
                 rigidBodyRefs={rigidBodyRefs}
               />
               <ObjectRenderer
-                dominoInfo={objectInfo}
+                dominoInfo={objectMetaData}
                 onPointerOver={(event) => openGuideToast(event, id)}
                 onPointerOut={closeGuideToast}
                 onClick={(event) => readyDominoSimulation(event, index)}

--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -16,8 +16,9 @@ const DominoEntity = ({
     <>
       {dominos.length
         && dominos.map((domino, index) => {
-          const { type, position, rotation, color, opacity, id, objectInfo } = domino;
-          const { colliders } = domino.objectInfo.paths;
+          const { position, rotation, color, opacity, id, objectInfo } = domino;
+          const { colliders, type } = domino.objectInfo.paths;
+
           return (
             <RigidBody
               type={type}

--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -1,0 +1,127 @@
+import { RigidBody, CuboidCollider } from "@react-three/rapier";
+import { useState } from "react";
+import * as THREE from "three";
+
+import { ObjectRenderer } from "@/components/DominoCanvas";
+import useCannonControls from "@/hooks/useCannonControls";
+import useDominoStore from "@/store/useDominoStore";
+
+const DominoEntity = ({
+  openGuideToast,
+  closeGuideToast,
+  readyDominoSimulation,
+  rigidBodyRefs,
+}) => {
+  const dominos = useDominoStore((state) => state.dominos);
+  const [lightOnMap, setLightOnMap] = useState({});
+
+  const { handleCannonTrigger } = useCannonControls();
+
+  return (
+    <>
+      {dominos.length
+        && dominos.map((domino, index) => {
+          const { type, position, rotation, color, opacity, id, objectInfo } = domino;
+          const { colliders } = domino.objectInfo.paths;
+          return (
+            <RigidBody
+              type={type}
+              colliders={colliders}
+              name={objectInfo.objectName}
+              key={id}
+              restitution={0}
+              friction={1}
+              linearDamping={0.01}
+              angularDamping={0.01}
+              position={position}
+              rotation={rotation}
+              ref={(ref) => (rigidBodyRefs.current[index] = ref)}
+            >
+              {objectInfo?.objectName === "cannon" && (
+                <>
+                  <CuboidCollider
+                    args={[0.2, 0.7, 0.2]}
+                    position={[0, 0, -1]}
+                    sensor
+                    onIntersectionEnter={({ other, target }) => {
+                      handleCannonTrigger(other, target);
+                    }}
+                  />
+                </>
+              )}
+
+              {objectInfo?.objectName === "lightbulb" && (
+                <>
+                  <CuboidCollider
+                    args={[0.3, 0.4, 0.4]}
+                    position={[1.65, -0.5, 1.25]}
+                    sensor
+                    onIntersectionEnter={(other) => {
+                      if (other.rigidBodyObject.name === "defaultObject") {
+                        setTimeout(() => {
+                          setLightOnMap((prev) => ({ ...prev, [id]: true }));
+                        }, 300);
+                      }
+                    }}
+                  />
+                  <mesh position={[0, 0.1, -0.2]}>
+                    <boxGeometry args={[1, 0.5, 0.4]} />
+                    <meshStandardMaterial
+                      color={lightOnMap[id] ? "white" : "gray"}
+                      emissive={lightOnMap[id] ? "rgb(255,255,150)" : "black"}
+                      emissiveIntensity={50}
+                      metalness={0.1}
+                      roughness={0.3}
+                      transparent
+                      opacity={0}
+                    />
+                    {lightOnMap[id] && (
+                      <pointLight
+                        position={[0, -0.5, 0]}
+                        color="yellow"
+                        intensity={30}
+                        distance={2}
+                        decay={1}
+                      />
+                    )}
+                  </mesh>
+                </>
+              )}
+              {objectInfo?.objectName === "bumper" && (
+                <>
+                  <CuboidCollider
+                    args={[0.5, 0.3, 0.5]}
+                    position={[0, 0.1, 0.2]}
+                    sensor
+                    onIntersectionEnter={({ other }) => {
+                      const otherObject = other.rigidBody;
+                      if (!otherObject) return;
+
+                      const dir = new THREE.Vector3()
+                        .subVectors(otherObject.translation(), new THREE.Vector3(...position))
+                        .setY(0)
+                        .normalize()
+                        .multiplyScalar(5);
+
+                      otherObject.applyImpulse({ x: dir.x, y: 0, z: dir.z }, true);
+                    }}
+                  />
+                </>
+              )}
+
+              <ObjectRenderer
+                dominoInfo={objectInfo}
+                onPointerOver={(event) => openGuideToast(event, id)}
+                onPointerOut={closeGuideToast}
+                onClick={(event) => readyDominoSimulation(event, index)}
+                opacity={opacity}
+                color={color}
+              />
+            </RigidBody>
+          );
+        })}
+    </>
+  );
+};
+
+export default DominoEntity;

--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -1,9 +1,7 @@
-import { RigidBody, CuboidCollider } from "@react-three/rapier";
-import { useState } from "react";
-import * as THREE from "three";
+import { RigidBody } from "@react-three/rapier";
 
 import { ObjectRenderer } from "@/components/DominoCanvas";
-import useCannonControls from "@/hooks/useCannonControls";
+import DominoVisualUnit from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/DominoVisualUnit";
 import useDominoStore from "@/store/useDominoStore";
 
 const DominoEntity = ({
@@ -13,9 +11,6 @@ const DominoEntity = ({
   rigidBodyRefs,
 }) => {
   const dominos = useDominoStore((state) => state.dominos);
-  const [lightOnMap, setLightOnMap] = useState({});
-
-  const { handleCannonTrigger } = useCannonControls();
 
   return (
     <>
@@ -37,78 +32,12 @@ const DominoEntity = ({
               rotation={rotation}
               ref={(ref) => (rigidBodyRefs.current[index] = ref)}
             >
-              {objectInfo?.objectName === "cannon" && (
-                <>
-                  <CuboidCollider
-                    args={[0.2, 0.7, 0.2]}
-                    position={[0, 0, -1]}
-                    sensor
-                    onIntersectionEnter={({ other, target }) => {
-                      handleCannonTrigger(other, target);
-                    }}
-                  />
-                </>
-              )}
-
-              {objectInfo?.objectName === "lightbulb" && (
-                <>
-                  <CuboidCollider
-                    args={[0.3, 0.4, 0.4]}
-                    position={[1.65, -0.5, 1.25]}
-                    sensor
-                    onIntersectionEnter={(other) => {
-                      if (other.rigidBodyObject.name === "defaultObject") {
-                        setTimeout(() => {
-                          setLightOnMap((prev) => ({ ...prev, [id]: true }));
-                        }, 300);
-                      }
-                    }}
-                  />
-                  <mesh position={[0, 0.1, -0.2]}>
-                    <boxGeometry args={[1, 0.5, 0.4]} />
-                    <meshStandardMaterial
-                      color={lightOnMap[id] ? "white" : "gray"}
-                      emissive={lightOnMap[id] ? "rgb(255,255,150)" : "black"}
-                      emissiveIntensity={50}
-                      metalness={0.1}
-                      roughness={0.3}
-                      transparent
-                      opacity={0}
-                    />
-                    {lightOnMap[id] && (
-                      <pointLight
-                        position={[0, -0.5, 0]}
-                        color="yellow"
-                        intensity={30}
-                        distance={2}
-                        decay={1}
-                      />
-                    )}
-                  </mesh>
-                </>
-              )}
-              {objectInfo?.objectName === "bumper" && (
-                <>
-                  <CuboidCollider
-                    args={[0.5, 0.3, 0.5]}
-                    position={[0, 0.1, 0.2]}
-                    sensor
-                    onIntersectionEnter={({ other }) => {
-                      const otherObject = other.rigidBody;
-                      if (!otherObject) return;
-
-                      const dir = new THREE.Vector3()
-                        .subVectors(otherObject.translation(), new THREE.Vector3(...position))
-                        .setY(0)
-                        .normalize()
-                        .multiplyScalar(5);
-
-                      otherObject.applyImpulse({ x: dir.x, y: 0, z: dir.z }, true);
-                    }}
-                  />
-                </>
-              )}
-
+              <DominoVisualUnit
+                objectName={objectInfo?.objectName}
+                id={id}
+                position={position}
+                rigidBodyRefs={rigidBodyRefs}
+              />
               <ObjectRenderer
                 dominoInfo={objectInfo}
                 onPointerOver={(event) => openGuideToast(event, id)}

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Bumper/Bumper.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Bumper/Bumper.jsx
@@ -1,0 +1,26 @@
+import { CuboidCollider } from "@react-three/rapier";
+import * as THREE from "three";
+
+const Bumper = ({ position }) => {
+  return (
+    <CuboidCollider
+      args={[0.5, 0.3, 0.5]}
+      position={[0, 0.1, 0.2]}
+      sensor
+      onIntersectionEnter={({ other }) => {
+        const otherObject = other.rigidBody;
+        if (!otherObject) return;
+
+        const dir = new THREE.Vector3()
+          .subVectors(otherObject.translation(), new THREE.Vector3(...position))
+          .setY(0)
+          .normalize()
+          .multiplyScalar(5);
+
+        otherObject.applyImpulse({ x: dir.x, y: 0, z: dir.z }, true);
+      }}
+    />
+  );
+};
+
+export default Bumper;

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Cannon/Cannon.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Cannon/Cannon.jsx
@@ -1,0 +1,20 @@
+import { CuboidCollider } from "@react-three/rapier";
+
+import useCannonControls from "@/hooks/useCannonControls";
+
+const Cannon = () => {
+  const { handleCannonTrigger } = useCannonControls();
+
+  return (
+    <CuboidCollider
+      args={[0.2, 0.7, 0.2]}
+      position={[0, 0, -1]}
+      sensor
+      onIntersectionEnter={({ other, target }) => {
+        handleCannonTrigger(other, target);
+      }}
+    />
+  );
+};
+
+export default Cannon;

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
@@ -4,7 +4,7 @@ import { Quaternion, Vector3 } from "three";
 
 import useDominoStore from "@/store/useDominoStore";
 
-const CarController = ({ rigidBodyRefs }) => {
+const Car = ({ rigidBodyRefs }) => {
   const dominos = useDominoStore((state) => state.dominos);
   const appliedImpulseIds = useRef(new Set());
 
@@ -42,4 +42,4 @@ const CarController = ({ rigidBodyRefs }) => {
   return null;
 };
 
-export default CarController;
+export default Car;

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
@@ -11,7 +11,7 @@ const Car = ({ rigidBodyRefs }) => {
   useFrame(() => {
     dominos.forEach((domino, index) => {
       const rigidBody = rigidBodyRefs.current[index];
-      const isCar = domino.objectMetaData.objectName === "car";
+      const isCar = domino.objectInfo.objectName === "car";
       const isValidRef = rigidBody && typeof rigidBody.mass === "function" && rigidBody.mass() > 0;
       const isNotApplied = !appliedImpulseIds.current.has(domino.id);
 

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car.jsx
@@ -11,7 +11,7 @@ const Car = ({ rigidBodyRefs }) => {
   useFrame(() => {
     dominos.forEach((domino, index) => {
       const rigidBody = rigidBodyRefs.current[index];
-      const isCar = domino.objectInfo.objectName === "car";
+      const isCar = domino.objectMetaData.objectName === "car";
       const isValidRef = rigidBody && typeof rigidBody.mass === "function" && rigidBody.mass() > 0;
       const isNotApplied = !appliedImpulseIds.current.has(domino.id);
 

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/DominoVisualUnit.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/DominoVisualUnit.jsx
@@ -1,0 +1,15 @@
+import Bumper from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/Bumper/Bumper";
+import Cannon from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/Cannon/Cannon";
+import Car from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/Car/Car";
+import LightBulb from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/LightBulb/LightBulb";
+
+const ObjectComponentMap = { bumper: Bumper, cannon: Cannon, car: Car, lightbulb: LightBulb };
+
+const DominoVisualUnit = ({ objectName, ...props }) => {
+  const Object = ObjectComponentMap[objectName];
+  if (!Object) return null;
+
+  return <Object {...props} />;
+};
+
+export default DominoVisualUnit;

--- a/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/LightBulb/LightBulb.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoVisualUnit/LightBulb/LightBulb.jsx
@@ -1,0 +1,46 @@
+import { CuboidCollider } from "@react-three/rapier";
+import { useState } from "react";
+
+const LightBulb = ({ id }) => {
+  const [lightOnMap, setLightOnMap] = useState({});
+
+  return (
+    <>
+      <CuboidCollider
+        args={[0.3, 0.4, 0.4]}
+        position={[1.65, -0.5, 1.25]}
+        sensor
+        onIntersectionEnter={(other) => {
+          if (other.rigidBodyObject.name === "defaultObject") {
+            setTimeout(() => {
+              setLightOnMap((prev) => ({ ...prev, [id]: true }));
+            }, 300);
+          }
+        }}
+      />
+      <mesh position={[0, 0.1, -0.2]}>
+        <boxGeometry args={[1, 0.5, 0.4]} />
+        <meshStandardMaterial
+          color={lightOnMap[id] ? "white" : "gray"}
+          emissive={lightOnMap[id] ? "rgb(255,255,150)" : "black"}
+          emissiveIntensity={50}
+          metalness={0.1}
+          roughness={0.3}
+          transparent
+          opacity={0}
+        />
+        {lightOnMap[id] && (
+          <pointLight
+            position={[0, -0.5, 0]}
+            color="yellow"
+            intensity={30}
+            distance={2}
+            decay={1}
+          />
+        )}
+      </mesh>
+    </>
+  );
+};
+
+export default LightBulb;

--- a/src/components/DominoCanvas/ObjectRenderer/ObjectRenderer.jsx
+++ b/src/components/DominoCanvas/ObjectRenderer/ObjectRenderer.jsx
@@ -21,8 +21,8 @@ const DefaultObject = ({ position, onPointerOver, onPointerOut, onClick, opacity
   );
 };
 
-const PrimitiveObject = ({ paths, position, onPointerOver, onPointerOut, onClick }) => {
-  const { scene } = useGLTF(paths);
+const PrimitiveObject = ({ path, position, onPointerOver, onPointerOut, onClick }) => {
+  const { scene } = useGLTF(path);
 
   const clonedScene = useMemo(() => scene.clone(true), [scene]);
 
@@ -49,7 +49,7 @@ const ObjectRenderer = ({
   opacity,
   color,
 }) => {
-  const { objectName, paths } = dominoInfo;
+  const { objectName, objectInfo } = dominoInfo;
   const isDefaultObject = objectName === "defaultObject";
 
   return isDefaultObject ?
@@ -62,7 +62,7 @@ const ObjectRenderer = ({
         color={color}
       />
     : <PrimitiveObject
-        paths={paths.model}
+        path={objectInfo.model}
         position={position}
         onPointerOver={onPointerOver}
         onPointerOut={onPointerOut}

--- a/src/components/DominoCanvas/ObjectRenderer/ObjectRenderer.jsx
+++ b/src/components/DominoCanvas/ObjectRenderer/ObjectRenderer.jsx
@@ -49,7 +49,7 @@ const ObjectRenderer = ({
   opacity,
   color,
 }) => {
-  const { objectName, objectInfo } = dominoInfo;
+  const { objectName, model } = dominoInfo;
   const isDefaultObject = objectName === "defaultObject";
 
   return isDefaultObject ?
@@ -62,7 +62,7 @@ const ObjectRenderer = ({
         color={color}
       />
     : <PrimitiveObject
-        path={objectInfo.model}
+        path={model}
         position={position}
         onPointerOver={onPointerOver}
         onPointerOut={onPointerOut}

--- a/src/components/DominoCanvas/index.js
+++ b/src/components/DominoCanvas/index.js
@@ -3,4 +3,3 @@ export { default as CameraControls } from "@/components/DominoCanvas/CameraContr
 export { default as CursorFollowerObject } from "@/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject";
 export { default as ObjectRenderer } from "@/components/DominoCanvas/ObjectRenderer/ObjectRenderer";
 export { default as DominoCanvas } from "@/components/DominoCanvas/DominoCanvas";
-export { default as CarController } from "@/components/DominoCanvas/CarController/CarController";

--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
-import ModalLayer from "../Common/ModalLayer";
-
+import ModalLayer from "@/Common/ModalLayer";
 import {
   GuideToast,
   HUDButtonGroup,

--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import ModalLayer from "../Common/ModalLayer";
+
 import {
   GuideToast,
   HUDButtonGroup,
@@ -24,6 +26,21 @@ const DominoHUD = ({ rigidBodyRefs, switchToReadyMode, isOpenGuideToastVisible }
     setClearConfirmModalOpen(false);
   };
 
+  const modals = [
+    { key: "guideToast", Component: GuideToast, isOpen: isOpenGuideToastVisible, props: {} },
+    {
+      key: "settingModal",
+      Component: SettingModal,
+      isOpen: isSettingModalOpen,
+      props: { closeModal: handleCloseModal },
+    },
+    {
+      key: "clearConfirmModal",
+      Component: DominoClearConfirmModal,
+      isOpen: isClearConfirmModalOpen,
+      props: { closeModal: handleCloseModal },
+    },
+  ];
   return (
     <>
       <HUDButtonGroup
@@ -40,10 +57,7 @@ const DominoHUD = ({ rigidBodyRefs, switchToReadyMode, isOpenGuideToastVisible }
       )}
 
       <SidePanel />
-      {isOpenGuideToastVisible && <GuideToast />}
-
-      {isSettingModalOpen && <SettingModal closeModal={handleCloseModal} />}
-      {isClearConfirmModalOpen && <DominoClearConfirmModal closeModal={handleCloseModal} />}
+      <ModalLayer modals={modals} />
     </>
   );
 };

--- a/src/components/DominoHUD/SettingModal/SettingModal.jsx
+++ b/src/components/DominoHUD/SettingModal/SettingModal.jsx
@@ -7,7 +7,7 @@ import SettingGroup from "@/components/DominoHUD/SettingModal/SettingGroup";
 import GroundTypeButton from "@/components/DominoHUD/SettingModal/GroundTypeButton";
 import ModalOverlay from "@/components/Common/ModalOverlay";
 
-const groundOptions = [
+const GROUND_OPTIONS = [
   { type: "grass", image: tileGrass },
   { type: "wood_dark", image: tileWoodDark },
   { type: "wood_light", image: tileWoodLight },
@@ -65,7 +65,7 @@ const SettingModal = ({ closeModal }) => {
 
         <SettingGroup title="배경">
           <ul className="flex gap-[10px]">
-            {groundOptions.map(({ type, image }) => (
+            {GROUND_OPTIONS.map(({ type, image }) => (
               <li key={type}>
                 <GroundTypeButton
                   type={type}

--- a/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
+++ b/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
@@ -26,7 +26,7 @@ export default function DominoColorPalette() {
         <button
           key={color.type}
           onClick={() => handleSelect(color.hex)}
-          className={`w-8 h-8 rounded-full`}
+          className={`w-8 h-8 rounded-full cursor-pointer`}
           style={{
             backgroundColor: color.hex,
             border: selectedColor === color.hex ? "3px solid white" : "none",

--- a/src/components/DominoHUD/SidePanel/ObjectCard.jsx
+++ b/src/components/DominoHUD/SidePanel/ObjectCard.jsx
@@ -8,7 +8,7 @@ const ObjectCard = ({ objectName, objectInfo, groupName }) => {
     <div
       key={objectName}
       className="group flex flex-col items-center gap-1 text-white text-xs cursor-pointer"
-      onClick={() => setSelectedDomino({ objectName, objectInfo, groupName })}
+      onClick={() => setSelectedDomino({ ...objectInfo, objectName, groupName })}
     >
       <div
         className={`${isSelected && "border-2 border-[#22ff00]"} w-26 h-26 bg-black/50 rounded overflow-hidden flex items-center justify-center`}

--- a/src/components/DominoHUD/SidePanel/ObjectCard.jsx
+++ b/src/components/DominoHUD/SidePanel/ObjectCard.jsx
@@ -1,6 +1,6 @@
 import useDominoStore from "@/store/useDominoStore";
 
-const ObjectCard = ({ objectName, paths, groupName }) => {
+const ObjectCard = ({ objectName, objectInfo, groupName }) => {
   const { selectedDomino, setSelectedDomino } = useDominoStore();
   const isSelected = selectedDomino?.objectName === objectName;
 
@@ -8,13 +8,13 @@ const ObjectCard = ({ objectName, paths, groupName }) => {
     <div
       key={objectName}
       className="group flex flex-col items-center gap-1 text-white text-xs cursor-pointer"
-      onClick={() => setSelectedDomino({ objectName, paths, groupName })}
+      onClick={() => setSelectedDomino({ objectName, objectInfo, groupName })}
     >
       <div
         className={`${isSelected && "border-2 border-[#22ff00]"} w-26 h-26 bg-black/50 rounded overflow-hidden flex items-center justify-center`}
       >
         <img
-          src={paths.thumbnail}
+          src={objectInfo.thumbnail}
           alt={objectName}
           draggable={false}
           className="w-full h-full object-contain transform transition-transform duration-200 group-hover:scale-130 select-none"

--- a/src/components/DominoHUD/SidePanel/SidePanel.jsx
+++ b/src/components/DominoHUD/SidePanel/SidePanel.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import DominoColorPalette from "@/components/DominoHUD/SidePanel/DominoColorPalette";
 import ObjectCard from "@/components/DominoHUD/SidePanel/ObjectCard";
-import { OBJECT_PATHS } from "@/constants/objectPaths";
+import { OBJECT_METADATA } from "@/constants/objectMetaData";
 import useDominoStore from "@/store/useDominoStore";
 
 const SidePanel = () => {
@@ -18,19 +18,19 @@ const SidePanel = () => {
       onMouseLeave={() => setIsOpen(false)}
     >
       <aside className="w-100 h-full bg-black/40 shadow-lg p-3 flex flex-col relative gap-6">
-        {selectedDomino && <DominoColorPalette />}
-        {Object.entries(OBJECT_PATHS).map(([groupName, groupObjects]) => (
+        {selectedDomino?.objectName === "defaultObject" && <DominoColorPalette />}
+        {Object.entries(OBJECT_METADATA).map(([groupName, groupObjects]) => (
           <section
             key={groupName}
             className="flex flex-col gap-2 overflow-y-auto"
           >
             <h2 className="font-bold text-white">{groupName.toLowerCase()}</h2>
             <div className="grid grid-cols-3 gap-4">
-              {Object.entries(groupObjects).map(([objectName, paths]) => (
+              {Object.entries(groupObjects).map(([objectName, objectInfo]) => (
                 <ObjectCard
                   key={objectName}
                   objectName={objectName}
-                  paths={paths}
+                  objectInfo={objectInfo}
                   groupName={groupName}
                 />
               ))}

--- a/src/constants/objectMetaData.js
+++ b/src/constants/objectMetaData.js
@@ -1,4 +1,4 @@
-export const OBJECT_PATHS = {
+export const OBJECT_METADATA = {
   STATIC_OBJECTS: {
     defaultObject: {
       thumbnail: "/images/domino.png",

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -9,10 +9,9 @@ import useDominoKeyboardControls from "@/hooks/useDominoKeyboardControls";
 import useDominoSimulation from "@/hooks/useDominoSimulation";
 import useToastControls from "@/hooks/useToastControls";
 import useDominoStore from "@/store/useDominoStore";
-import useSettingStore from "@/store/useSettingStore";
+
 const DominoScene = () => {
   const dominos = useDominoStore((state) => state.dominos);
-  const rotationSensitivity = useSettingStore((state) => state.rotationSensitivity);
   const [lightOnMap, setlightOnMap] = useState({});
   const { isOpenGuideToastVisible, openGuideToast, closeGuideToast, setIsGuideToastVisible } =
     useToastControls();
@@ -27,7 +26,7 @@ const DominoScene = () => {
         rigidBodyRefs={rigidBodyRefs}
         switchToReadyMode={switchToReadyMode}
       />
-      <DominoCanvas rotationSensitivity={rotationSensitivity}>
+      <DominoCanvas>
         {dominos.length
           && dominos.map((domino, index) => {
             const { type, position, rotation, color, opacity, id, objectInfo } = domino;

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -1,24 +1,16 @@
-import { RigidBody, CuboidCollider } from "@react-three/rapier";
-import { useState } from "react";
-import * as THREE from "three";
-
-import { Ground, ObjectRenderer, DominoCanvas, CarController } from "@/components/DominoCanvas";
+import { Ground, DominoCanvas, CarController } from "@/components/DominoCanvas";
 import DominoHUD from "@/components/DominoHUD/DominoHUD";
-import useCannonControls from "@/hooks/useCannonControls";
 import useDominoKeyboardControls from "@/hooks/useDominoKeyboardControls";
 import useDominoSimulation from "@/hooks/useDominoSimulation";
 import useToastControls from "@/hooks/useToastControls";
-import useDominoStore from "@/store/useDominoStore";
 
 const DominoScene = () => {
-  const dominos = useDominoStore((state) => state.dominos);
-  const [lightOnMap, setlightOnMap] = useState({});
   const { isOpenGuideToastVisible, openGuideToast, closeGuideToast, setIsGuideToastVisible } =
     useToastControls();
   const { rigidBodyRefs, readyDominoSimulation, switchToReadyMode } = useDominoSimulation();
-  const { handleCannonTrigger } = useCannonControls();
 
   useDominoKeyboardControls(setIsGuideToastVisible);
+
   return (
     <>
       <DominoHUD
@@ -26,111 +18,12 @@ const DominoScene = () => {
         rigidBodyRefs={rigidBodyRefs}
         switchToReadyMode={switchToReadyMode}
       />
-      <DominoCanvas>
-        {dominos.length
-          && dominos.map((domino, index) => {
-            const { type, position, rotation, color, opacity, id, objectInfo } = domino;
-            const { colliders } = domino.objectInfo.paths;
-            return (
-              <RigidBody
-                type={type}
-                colliders={colliders}
-                name={objectInfo.objectName}
-                key={id}
-                restitution={0}
-                friction={1}
-                linearDamping={0.01}
-                angularDamping={0.01}
-                position={position}
-                rotation={rotation}
-                ref={(ref) => (rigidBodyRefs.current[index] = ref)}
-              >
-                {objectInfo?.objectName === "cannon" && (
-                  <>
-                    <CuboidCollider
-                      args={[0.2, 0.7, 0.2]}
-                      position={[0, 0, -1]}
-                      sensor
-                      onIntersectionEnter={({ other, target }) => {
-                        handleCannonTrigger(other, target);
-                      }}
-                    />
-                  </>
-                )}
-
-                {objectInfo?.objectName === "lightbulb" && (
-                  <>
-                    <CuboidCollider
-                      args={[0.3, 0.4, 0.4]}
-                      position={[1.65, -0.5, 1.25]}
-                      sensor
-                      onIntersectionEnter={(other) => {
-                        if (other.rigidBodyObject.name === "defaultObject") {
-                          setTimeout(() => {
-                            setlightOnMap((prev) => ({ ...prev, [id]: true }));
-                          }, 300);
-                        }
-                      }}
-                    />
-                    <mesh position={[0, 0.1, -0.2]}>
-                      <boxGeometry args={[1, 0.5, 0.4]} />
-                      <meshStandardMaterial
-                        color={lightOnMap[id] ? "white" : "gray"}
-                        emissive={lightOnMap[id] ? "rgb(255,255,150)" : "black"}
-                        emissiveIntensity={50}
-                        metalness={0.1}
-                        roughness={0.3}
-                        transparent
-                        opacity={0}
-                      />
-                      {lightOnMap[id] && (
-                        <pointLight
-                          position={[0, -0.5, 0]}
-                          color="yellow"
-                          intensity={30}
-                          distance={2}
-                          decay={1}
-                        />
-                      )}
-                    </mesh>
-                  </>
-                )}
-                {objectInfo?.objectName === "bumper" && (
-                  <>
-                    <CuboidCollider
-                      args={[0.5, 0.3, 0.5]}
-                      position={[0, 0.1, 0.2]}
-                      sensor
-                      onIntersectionEnter={({ other }) => {
-                        const otherObject = other.rigidBody;
-                        if (!otherObject) return;
-
-                        const dir = new THREE.Vector3()
-                          .subVectors(otherObject.translation(), new THREE.Vector3(...position))
-                          .setY(0)
-                          .normalize()
-                          .multiplyScalar(5);
-
-                        otherObject.applyImpulse({ x: dir.x, y: 0, z: dir.z }, true);
-                      }}
-                    />
-                  </>
-                )}
-
-                <ObjectRenderer
-                  dominoInfo={objectInfo}
-                  onPointerOver={(event) => openGuideToast(event, id)}
-                  onPointerOut={closeGuideToast}
-                  onClick={(event) => readyDominoSimulation(event, index)}
-                  opacity={opacity}
-                  color={color}
-                />
-              </RigidBody>
-            );
-          })}
-        <CarController rigidBodyRefs={rigidBodyRefs} />
-        <Ground />
-      </DominoCanvas>
+      <DominoCanvas
+        openGuideToast={openGuideToast}
+        closeGuideToast={closeGuideToast}
+        readyDominoSimulation={readyDominoSimulation}
+        rigidBodyRefs={rigidBodyRefs}
+      />
     </>
   );
 };

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -23,6 +23,7 @@ const DominoScene = () => {
         closeGuideToast={closeGuideToast}
         readyDominoSimulation={readyDominoSimulation}
         rigidBodyRefs={rigidBodyRefs}
+        isOpenGuideToastVisible={isOpenGuideToastVisible}
       />
     </>
   );

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -1,4 +1,4 @@
-import { Ground, DominoCanvas, CarController } from "@/components/DominoCanvas";
+import { DominoCanvas } from "@/components/DominoCanvas";
 import DominoHUD from "@/components/DominoHUD/DominoHUD";
 import useDominoKeyboardControls from "@/hooks/useDominoKeyboardControls";
 import useDominoSimulation from "@/hooks/useDominoSimulation";


### PR DESCRIPTION
## #️⃣ Issue Number #74

## 📝 요약(Summary)
- 전체 구조의 책임 분리를 명확히 하고, 도미노 렌더링 관련 상태를 적절한 컴포넌트와 훅으로 분리하였습니다.
- 조건문 제거, 변수명 명확화, 모달 렌더링 로직 중복 제거 등을 포함한 전반적인 리팩토링을 수행하였습니다.

### 주요 변경사항
- `DominoCanvas`: THREE.js 관련 렌더링 책임만 갖도록 분리
- `DominoEntity`: 물리엔진 기반 도미노 렌더링 책임 집중
- `DominoVisualUnit`: 오브젝트 이름 기반 렌더링 컴포넌트 매핑 구조 도입 (맵 기반)
- `Bumper`, `Cannon`, `Car`, `LightBulb`: 단일 책임 원칙(SRP)에 따라 각각 분리
- `ModalLayer`: 중복 모달 렌더링 로직 제거 및 배열 기반으로 통합 렌더링 처리
- `OBJECT_PATHS` → `DOMINO_METADATA`, 내부 `paths` → `objectInfo` 로 명확한 역할 표현
- `bbox` → `boundingBox`, `y` → `placementY`, `groundOptions` → `GROUND_OPTIONS` 등 명확한 변수명 변경
- `type` 누락 구조분해 오류 수정

## 📸 스크린샷 (선택)
리팩토링 전: 렌더링 트리에서 25개 컴포넌트가 업데이트됨.

<img width="623" alt="스크린샷 2025-06-04 오후 2 49 23" src="https://github.com/user-attachments/assets/a3130514-7294-4daa-a43b-468374a4c3d6" />

리팩토링 후: 최적화 이후 15개만 리렌더링되고 있음.

<img width="623" alt="스크린샷 2025-06-04 오후 9 07 49" src="https://github.com/user-attachments/assets/0401bf33-1367-489b-9049-34c799ae88c6" />

## 💬 공유사항 to 리뷰어
- `DominoEntity` 및 `DominoVisualUnit`의 역할 분리가 적절한지, props 전달 구조가 명확한지 검토 부탁드립니다.
- `ModalLayer`의 렌더링 방식 개선에 대해 더 나은 구조가 있을지 의견 주시면 감사하겠습니다.
- 변수명 변경 등 컨벤션에 대한 추가 피드백도 환영입니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.