### PR TITLE
Feature: 로그인 기능 구현 (카카오 OAuth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.*

--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import ModalLayer from "@/Common/ModalLayer";
+import ModalLayer from "@/components/Common/ModalLayer";
 import {
   GuideToast,
   HUDButtonGroup,

--- a/src/components/KakaoLogin.jsx
+++ b/src/components/KakaoLogin.jsx
@@ -9,15 +9,15 @@ const SocialKakao = () => {
   return (
     <>
       <div className="flex items-center justify-center h-screen">
-        <div className="mt-[70vh]">
+        <div className="mt-[60vh]">
           <button
             onClick={handleLogin}
-            className="flex items-center justify-center gap-3 bg-[#FEE500] text-[#3C1E1E] hover:bg-[#e5d500] px-5 py-3 rounded-xl font-semibold shadow-md transition duration-200"
+            className="flex items-center justify-center gap-4 bg-[#FEE500] text-[#3C1E1E] hover:bg-[#e5d500] px-8 py-5 rounded-xl font-semibold text-lg shadow-md transition duration-200"
           >
             <img
               src="https://developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_medium.png"
               alt="Kakao"
-              className="w-[25px] h-[25px]"
+              className="w-[30px] h-[30px]"
             />
             카카오 로그인
           </button>

--- a/src/components/KakaoLogin.jsx
+++ b/src/components/KakaoLogin.jsx
@@ -1,9 +1,8 @@
 const SocialKakao = () => {
-  const redirect_uri = "http://localhost:5173/oauth/callback";
-
   const VITE_KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  const VITE_KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
-  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${redirect_uri}&response_type=code`;
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${VITE_KAKAO_REDIRECT_URI}&response_type=code`;
   const handleLogin = () => {
     window.location.href = kakaoURL;
   };

--- a/src/components/KakaoLogin.jsx
+++ b/src/components/KakaoLogin.jsx
@@ -1,0 +1,30 @@
+const SocialKakao = () => {
+  const redirect_uri = "http://localhost:5173/game";
+
+  const VITE_KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${redirect_uri}&response_type=code`;
+  const handleLogin = () => {
+    window.location.href = kakaoURL;
+  };
+  return (
+    <>
+      <div className="flex items-center justify-center h-screen">
+        <div className="mt-[70vh]">
+          <button
+            onClick={handleLogin}
+            className="flex items-center justify-center gap-3 bg-[#FEE500] text-[#3C1E1E] hover:bg-[#e5d500] px-5 py-3 rounded-xl font-semibold shadow-md transition duration-200"
+          >
+            <img
+              src="https://developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_medium.png"
+              alt="Kakao"
+              className="w-[25px] h-[25px]"
+            />
+            카카오 로그인
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+export default SocialKakao;

--- a/src/components/KakaoLogin.jsx
+++ b/src/components/KakaoLogin.jsx
@@ -1,5 +1,5 @@
 const SocialKakao = () => {
-  const redirect_uri = "http://localhost:5173/game";
+  const redirect_uri = "http://localhost:5173/oauth/callback";
 
   const VITE_KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
 

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+const Game = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const refreshAccessToken = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_BACKEND_API}/auth/refresh`, {
+          method: "POST",
+          credentials: "include",
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) throw new Error(data.message);
+
+        localStorage.setItem("dominoAccessToken", data.token);
+      } catch (err) {
+        console.error("access token 갱신 실패", err.message);
+        navigate("/");
+      }
+    };
+
+    refreshAccessToken();
+  }, [navigate]);
+};
+
+export default Game;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
 
+import KakaoLogin from "@/components/KakaoLogin";
+
 import logo from "/images/logo.png";
 import startButton from "/images/start_button.png";
 
@@ -23,6 +25,7 @@ const Home = () => {
           draggable="false"
         />
       </Link>
+      <KakaoLogin />
     </section>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import KakaoLogin from "@/components/KakaoLogin";
 
 import logo from "/images/logo.png";
-import startButton from "/images/start_button.png";
 
 const Home = () => {
   return (
@@ -15,17 +14,6 @@ const Home = () => {
           draggable="false"
         />
       </h1>
-      <Link
-        to="/game"
-        className="block absolute left-1/2 bottom-[20%] transform -translate-x-1/2 w-[60%] max-w-[300px] cursor-pointer"
-      >
-        <img
-          src={startButton}
-          alt="시작버튼"
-          draggable="false"
-        />
-      </Link>
-
       <KakaoLogin />
     </section>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,9 +25,8 @@ const Home = () => {
           draggable="false"
         />
       </Link>
-      <Link to="/oauth/login">
-        <KakaoLogin />
-      </Link>
+
+      <KakaoLogin />
     </section>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,7 +25,9 @@ const Home = () => {
           draggable="false"
         />
       </Link>
-      <KakaoLogin />
+      <Link to="/oauth/login">
+        <KakaoLogin />
+      </Link>
     </section>
   );
 };

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+const OAuthCallback = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get("code");
+
+    if (code) {
+      fetch("http://localhost:3000/oauth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error("서버 응답 실패");
+          return res.json();
+        })
+        .then((data) => {
+          console.log("로그인 성공", data);
+          navigate("/game");
+        })
+        .catch((err) => {
+          console.error("로그인 실패", err);
+        });
+    } else {
+      console.error("인가 코드 없음!");
+      navigate("/");
+    }
+  }, [navigate]);
+
+  return <p>로그인 처리 중...</p>;
+};
+
+export default OAuthCallback;

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -8,7 +8,7 @@ const OAuthCallback = () => {
     const code = new URL(window.location.href).searchParams.get("code");
 
     if (code) {
-      fetch("http://localhost:3000/oauth/login", {
+      fetch("http://localhost:3000/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ code }),

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -14,22 +14,23 @@ const OAuthCallback = () => {
       }
 
       try {
-        const response = await fetch(`${import.meta.env.VITE_BACKEND_API}`, {
+        const response = await fetch(`${import.meta.env.VITE_BACKEND_API}/auth/login`, {
           method: "POST",
-          headers: { "Content-Type": "application/json", "credentials": "include" },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({ code }),
         });
+        const data = await response.json();
+        localStorage.setItem("dominoAccessToken", data.token);
 
         if (!response.ok) {
           const errorData = await response.json();
 
           if (errorData.message?.includes("KOE320")) {
             console.warn("만료된 인가 코드, 카카오 로그인 다시 시도");
-
             window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${
               import.meta.env.VITE_KAKAO_REST_API_KEY
             }&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code`;
-
             return;
           }
           throw new Error("서버 응답 실패!!!");

--- a/src/routers/routes.jsx
+++ b/src/routers/routes.jsx
@@ -11,7 +11,6 @@ const routes = createBrowserRouter([
   { path: "game", element: <DominoScene /> },
   { path: "projects/:projectId", element: <DominoScene /> },
   { path: "*", element: <NotFound /> },
-  { path: "/oauth/login", element: <KakaoLogin /> },
   { path: "/oauth/callback", element: <OAuthCallback /> },
 ]);
 

--- a/src/routers/routes.jsx
+++ b/src/routers/routes.jsx
@@ -1,14 +1,18 @@
 import { createBrowserRouter } from "react-router-dom";
 
+import KakaoLogin from "@/components/KakaoLogin";
 import DominoScene from "@/pages/DominoScene";
 import Home from "@/pages/Home";
 import NotFound from "@/pages/NotFound";
+import OAuthCallback from "@/pages/OAuthCallback";
 
 const routes = createBrowserRouter([
   { path: "/", element: <Home /> },
   { path: "game", element: <DominoScene /> },
   { path: "projects/:projectId", element: <DominoScene /> },
   { path: "*", element: <NotFound /> },
+  { path: "/oauth/login", element: <KakaoLogin /> },
+  { path: "/oauth/callback", element: <OAuthCallback /> },
 ]);
 
 export default routes;

--- a/src/routers/routes.jsx
+++ b/src/routers/routes.jsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from "react-router-dom";
 
-import KakaoLogin from "@/components/KakaoLogin";
 import DominoScene from "@/pages/DominoScene";
+import Game from "@/pages/Game";
 import Home from "@/pages/Home";
 import NotFound from "@/pages/NotFound";
 import OAuthCallback from "@/pages/OAuthCallback";
@@ -12,6 +12,7 @@ const routes = createBrowserRouter([
   { path: "projects/:projectId", element: <DominoScene /> },
   { path: "*", element: <NotFound /> },
   { path: "/oauth/callback", element: <OAuthCallback /> },
+  { path: "/game", element: <Game /> },
 ]);
 
 export default routes;


### PR DESCRIPTION
## #️⃣ Issue Number #75 

## 📝 요약(Summary)
카카오 소셜 로그인을 구현하여 사용자가 카카오 계정을 통해 손쉽게 로그인할 수 있도록 기능을 추가했습니다.
프론트엔드에서는 인가 코드(code)를 받아 백엔드에 전달하고, 백엔드에서는 해당 코드로 access_token을 발급받은 뒤 사용자 정보를 조회하여 로그인 처리를 수행합니다.
JWT 기반의 Access Token과 Refresh Token을 발급하여 인증 상태를 유지하며, Refresh Token은 httpOnly 쿠키에 저장하여 보안성을 강화했습니다. (cookie-parser 미들웨어 사용)
또한, KOE320 오류(재사용된 인가 코드) 대응 로직과 함께 fetch 요청에 credentials: "include"를 적용하여 쿠키 기반 인증 흐름이 원활하게 작동하도록 설정하였습니다.


## 💬 공유사항 to 리뷰어
- 논의 끝에 cookie-parser 미들웨어를 도입하였습니다.
이 미들웨어는 클라이언트로부터 전달된 쿠키를 자동으로 파싱해 req.cookies에 담아주므로, 편의성과 안정성 측면에서 유리하며, 추후 인증 정보를 보다 명확하고 일관된 방식으로 처리할 수 있을 것으로 판단했습니다. (실제로 Chrome 환경에서 쿠키가 정상적으로 설정된 것을 확인하였으며, 앞으로 fetch 요청 시에는 credentials: "include" 옵션을 반드시 추가해야 합니다.)

- 현재 로그인 처리 이후 즉시 화면이 전환되는데, 사용자 경험 개선을 위해 추후 로딩 상태를 표시하는 UI(로딩 스피너 등)를 추가할 예정입니다. 이 부분은 다음 회의 후 다룰 예정입니다. 
- 배포 이후 서비스 환경에 맞춰 백엔드에서 사용 중인 URL을 새로운 도메인으로 변경할 예정입니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.