### PR TITLE
Test: DominoHUD 및 SidePanel 컴포넌트 통합 테스트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react-swc": "^3.9.0",
         "@vitest/coverage-v8": "^3.2.1",
+        "@vitest/ui": "^3.2.1",
         "eslint": "^9.25.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1072,6 +1073,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@react-three/drei": {
       "version": "10.0.8",
@@ -2324,6 +2332,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.1.tgz",
+      "integrity": "sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.1",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/utils": {
@@ -5663,6 +5693,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6685,6 +6725,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -7227,6 +7282,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/coverage-v8": "^3.2.1",
+    "@vitest/ui": "^3.2.1",
     "eslint": "^9.25.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/__test__/components/DominoHUD.integration.test.jsx
+++ b/src/__test__/components/DominoHUD.integration.test.jsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import GlobalPortal from "@/components/Common/GlobalPortal";
+import DominoHUD from "@/components/DominoHUD/DominoHUD";
+
+vi.mock("@/store/useSimulationStore", () => ({
+  default: () => ({ simulationMode: "EDIT", countdownNumber: 3 }),
+}));
+
+const mockReset = vi.fn();
+
+vi.mock("@/hooks/useDominoReset", () => ({
+  default: () => ({ resetDominoSimulation: mockReset }),
+}));
+
+describe("DominoHUD Component 통합 테스트", () => {
+  const rigidBodyRefs = [];
+  const switchToReadyMode = vi.fn();
+
+  it("기본 버튼 요소들이 렌더링되어야 한다.", () => {
+    render(
+      <DominoHUD
+        rigidBodyRefs={rigidBodyRefs}
+        switchToReadyMode={switchToReadyMode}
+        isOpenGuideToastVisible={false}
+      />,
+    );
+
+    expect(screen.getByAltText("setting")).toBeInTheDocument();
+    expect(screen.getByAltText("play")).toBeInTheDocument();
+    expect(screen.getByAltText("reset")).toBeInTheDocument();
+    expect(screen.getByAltText("clear")).toBeInTheDocument();
+  });
+
+  it("COUNTDOWN 모드일 때 카운트다운 숫자가 표시되어야 한다.", async () => {
+    vi.resetModules();
+
+    vi.doMock("@/store/useSimulationStore", () => ({
+      default: () => ({ simulationMode: "COUNTDOWN", countdownNumber: 5 }),
+    }));
+
+    const { default: DominoHUDComponent } = await import("@/components/DominoHUD/DominoHUD");
+
+    render(
+      <DominoHUDComponent
+        rigidBodyRefs={rigidBodyRefs}
+        switchToReadyMode={switchToReadyMode}
+        isOpenGuideToastVisible={false}
+      />,
+    );
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("초기화 버튼 클릭 시 resetDominoSimulation이 호출되어야 한다.", () => {
+    render(
+      <DominoHUD
+        rigidBodyRefs={rigidBodyRefs}
+        switchToReadyMode={switchToReadyMode}
+        isOpenGuideToastVisible={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByAltText("reset"));
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it("설정 버튼 클릭 시 SettingModal이 열려야 한다.", () => {
+    render(
+      <GlobalPortal>
+        <DominoHUD
+          rigidBodyRefs={rigidBodyRefs}
+          switchToReadyMode={switchToReadyMode}
+          isOpenGuideToastVisible={false}
+        />
+      </GlobalPortal>,
+    );
+
+    fireEvent.click(screen.getByAltText("setting"));
+    expect(screen.getByText("배경 음악 음량")).toBeInTheDocument();
+    expect(screen.getByText("효과음 음량")).toBeInTheDocument();
+    expect(screen.getByText("배경")).toBeInTheDocument();
+  });
+
+  it("전체 제거 버튼 클릭 시 ConfirmModal이 열려야 한다", () => {
+    render(
+      <GlobalPortal>
+        <DominoHUD
+          rigidBodyRefs={rigidBodyRefs}
+          switchToReadyMode={switchToReadyMode}
+          isOpenGuideToastVisible={false}
+        />
+      </GlobalPortal>,
+    );
+
+    fireEvent.click(screen.getByAltText("clear"));
+
+    expect(screen.getByText("정말 Reset하시겠습니까?")).toBeInTheDocument();
+    expect(screen.getByText("이 작업은 되돌릴 수 없습니다.")).toBeInTheDocument();
+  });
+
+  it("모달 닫기 버튼 클릭 시 handleCloseModal이 모달을 닫아야 한다.", () => {
+    render(
+      <GlobalPortal>
+        <DominoHUD
+          rigidBodyRefs={rigidBodyRefs}
+          switchToReadyMode={switchToReadyMode}
+          isOpenGuideToastVisible={false}
+        />
+      </GlobalPortal>,
+    );
+    fireEvent.click(screen.getByAltText("setting"));
+    expect(screen.getByText("배경 음악 음량")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByAltText("close_button"));
+
+    expect(screen.queryByText("배경 음악 음량")).not.toBeInTheDocument();
+  });
+
+  it("확인 버튼 클릭 시 모달이 닫혀야 한다.", () => {
+    render(
+      <GlobalPortal>
+        <DominoHUD
+          rigidBodyRefs={rigidBodyRefs}
+          switchToReadyMode={switchToReadyMode}
+          isOpenGuideToastVisible={false}
+        />
+      </GlobalPortal>,
+    );
+
+    fireEvent.click(screen.getByAltText("clear"));
+    expect(screen.getByText("정말 Reset하시겠습니까?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "확인" }));
+
+    expect(screen.queryByText("정말 Reset하시겠습니까?")).not.toBeInTheDocument();
+  });
+});

--- a/src/__test__/components/GuideToast.test.jsx
+++ b/src/__test__/components/GuideToast.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GuideToast } from "@/components/DominoHUD";
+
+describe("GuideToast Component 테스트", () => {
+  it("Remove와 Hide 가이드 텍스트가 렌더링 되어야 한다.", () => {
+    render(<GuideToast />);
+    expect(screen.getByText("Remove")).toBeInTheDocument();
+    expect(screen.getByText("Hide")).toBeInTheDocument();
+  });
+
+  it("X와 H 키 안내가 포함되어 있어야 한다.", () => {
+    render(<GuideToast />);
+    expect(screen.getByText("X")).toBeInTheDocument();
+    expect(screen.getByText("H")).toBeInTheDocument();
+  });
+});

--- a/src/__test__/components/SidePanel.integration.test.jsx
+++ b/src/__test__/components/SidePanel.integration.test.jsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { SidePanel } from "@/components/DominoHUD";
+import useDominoStore from "@/store/useDominoStore";
+
+beforeEach(() => {
+  const { setSelectedDomino, setSelectedColor } = useDominoStore.getState();
+  setSelectedDomino({ objectName: "defaultObject" });
+  setSelectedColor(null);
+});
+describe("SidePanel Component 통합 테스트", () => {
+  it("사이드 패널은 기본적으로 닫힌 상태로 렌더링 되어야 한다.", () => {
+    const { container } = render(<SidePanel />);
+    const wrapper = container.firstChild;
+
+    expect(wrapper).toHaveClass("translate-x-[99%]");
+  });
+
+  it("사이드 패널에 마우스를 올리면 패널이 열려야 한다.", () => {
+    const { container } = render(<SidePanel />);
+    const wrapper = container.firstChild;
+
+    fireEvent.mouseEnter(wrapper);
+
+    expect(wrapper).toHaveClass("translate-x-0");
+  });
+
+  it("사이드 패널에 마우스를 내리면 패널이 닫혀야 한다.", () => {
+    const { container } = render(<SidePanel />);
+    const wrapper = container.firstChild;
+
+    fireEvent.mouseEnter(wrapper);
+    fireEvent.mouseLeave(wrapper);
+
+    expect(wrapper).toHaveClass("translate-x-[99%]");
+  });
+
+  it("선택한 도미노가 defaultObject면 DominoColorPalette 컴포넌트가 렌더링 되어야 한다.", () => {
+    const { getByTestId } = render(<SidePanel />);
+
+    const palette = getByTestId("domino-color-palette");
+    expect(palette).toBeInTheDocument();
+  });
+
+  it("DominoColorPalette에서 색상을 선택하면 선택한 색으로 도미노 상태가 변경되어야 한다.", () => {
+    render(<SidePanel />);
+
+    const redButton = screen.getByTestId("color-button-red");
+
+    act(() => {
+      fireEvent.click(redButton);
+    });
+
+    const { selectedColor } = useDominoStore.getState();
+    expect(selectedColor).toBe("#EF4444");
+  });
+
+  it("오브젝트를 선택하면 해당 오브젝트로 도미노 상태가 변경되어야 한다.", () => {
+    const { container } = render(<SidePanel />);
+    const wrapper = container.firstChild;
+
+    fireEvent.mouseEnter(wrapper);
+
+    const slideObjectButton = screen.getByTestId("object-button-slide");
+
+    act(() => {
+      fireEvent.click(slideObjectButton);
+    });
+
+    const { selectedDomino } = useDominoStore.getState();
+    expect(selectedDomino.objectName).toBe("slide");
+  });
+});

--- a/src/components/Common/ModalOverlay.jsx
+++ b/src/components/Common/ModalOverlay.jsx
@@ -27,7 +27,7 @@ const ModalOverlay = ({ closeModal, children }) => {
             <img
               src={closeButton}
               className="w-[30px] h-[30px]"
-              alt=""
+              alt="close_button"
             />
           </button>
           {children}

--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import ModalLayer from "@/Common/ModalLayer";
+import ModalLayer from "@/components/Common/ModalLayer";
 import {
   GuideToast,
   HUDButtonGroup,

--- a/src/components/DominoHUD/HUDButtonGroup/HUDButton.jsx
+++ b/src/components/DominoHUD/HUDButtonGroup/HUDButton.jsx
@@ -1,6 +1,6 @@
 import useDominoStore from "@/store/useDominoStore";
 
-const HUDButton = ({ onClick, buttonImage }) => {
+const HUDButton = ({ onClick, buttonImage, alt }) => {
   const setSelectedDomino = useDominoStore((state) => state.setSelectedDomino);
 
   return (
@@ -14,6 +14,7 @@ const HUDButton = ({ onClick, buttonImage }) => {
           src={buttonImage}
           draggable="false"
           className="w-full h-full"
+          alt={alt}
         />
       </button>
     </>

--- a/src/components/DominoHUD/HUDButtonGroup/HUDButtonGroup.jsx
+++ b/src/components/DominoHUD/HUDButtonGroup/HUDButtonGroup.jsx
@@ -15,11 +15,13 @@ const HUDButtons = ({ onClickSetting, onClickReset, onClickPlay, onClickClear })
       <HUDButton
         onClick={onClickSetting}
         buttonImage={settingButton}
+        alt="setting"
       />
       {simulationMode === MODE.EDIT && (
         <HUDButton
           onClick={onClickPlay}
           buttonImage={playButton}
+          alt="play"
         />
       )}
       {simulationMode !== MODE.COUNTDOWN && (
@@ -27,10 +29,12 @@ const HUDButtons = ({ onClickSetting, onClickReset, onClickPlay, onClickClear })
           <HUDButton
             onClick={onClickReset}
             buttonImage={resetButton}
+            alt="reset"
           />
           <HUDButton
             onClick={onClickClear}
             buttonImage={clearButton}
+            alt="clear"
           />
         </>
       )}

--- a/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
+++ b/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
@@ -21,11 +21,15 @@ export default function DominoColorPalette() {
   };
 
   return (
-    <div className="flex gap-2 p-3 rounded-xl bg-gray-100 shadow-inner w-fit opacity-90">
+    <div
+      data-testid="domino-color-palette"
+      className="flex gap-2 p-3 rounded-xl bg-gray-100 shadow-inner w-fit opacity-90"
+    >
       {COLORS.map((color) => (
         <button
           key={color.type}
           onClick={() => handleSelect(color.hex)}
+          data-testid={`color-button-${color.type}`}
           className={`w-8 h-8 rounded-full cursor-pointer`}
           style={{
             backgroundColor: color.hex,

--- a/src/components/DominoHUD/SidePanel/ObjectCard.jsx
+++ b/src/components/DominoHUD/SidePanel/ObjectCard.jsx
@@ -7,6 +7,7 @@ const ObjectCard = ({ objectName, objectInfo, groupName }) => {
   return (
     <div
       key={objectName}
+      data-testid={`object-button-${objectName}`}
       className="group flex flex-col items-center gap-1 text-white text-xs cursor-pointer"
       onClick={() => setSelectedDomino({ ...objectInfo, objectName, groupName })}
     >


### PR DESCRIPTION
## #️⃣ Issue Number #81 

## 📝 요약(Summary)
- `DominoHUD`와 `SidePanel` 컴포넌트에 대한 통합 테스트를 작성하였습니다.  
- 주요 UI 요소 렌더링 여부, 버튼 인터랙션, 모달 동작, 전역 상태 변경 흐름 등을 검증하며,  
- `useSimulationStore`, `useDominoStore`, `useDominoReset`에 대한 mocking을 적용했습니다.

## 📸 스크린샷 (선택)

<img width="753" alt="스크린샷 2025-06-06 오전 11 02 38" src="https://github.com/user-attachments/assets/94275904-f134-4e02-87db-8ab2d331e37f" />

## ✅ 주요 변경 사항
### DominoHUD 통합 테스트
- 기본 버튼들(clear, setting, reset, help) 렌더링 여부 테스트
- `COUNTDOWN` 모드 진입 시 카운트 숫자 표시 확인
- reset 버튼 클릭 시 `resetDominoSimulation()` 함수 호출 여부 테스트
- setting 버튼 클릭 시 설정 모달 렌더링 확인
- clear 버튼 클릭 시 확인 모달 렌더링 확인
- 모달 내 닫기 / 확인 버튼 클릭 시 정상 동작 여부 테스트
- `useSimulationStore`, `useDominoReset` mocking 처리

### SidePanel 통합 테스트
- 사이드 패널 기본 닫힘 상태 확인
- 마우스 hover 시 패널이 열리는지, mouse leave 시 닫히는지 테스트
- 선택한 도미노가 `defaultObject`일 경우 컬러 팔레트 렌더링 여부 확인
- 색상 버튼 클릭 시 `selectedColor` 전역 상태 변경 여부 테스트
- `ObjectCard` 클릭 시 `selectedDomino` 전역 상태가 해당 오브젝트로 변경되는지 검증

## 💬 공유사항 to 리뷰어
- `SidePanel`과 `DominoHUD` 내부 상태 변화가 전역 store를 통해 잘 반영되는지 중점 확인 부탁드립니다.
- 현재는 전역 상태를 직접 초기화하여 테스트를 구성했지만, 추후 테스트 안정성을 높이기 위한 helper 함수 도입도 고려하고 있습니다.
- `data-testid` 명명 규칙 및 도미노 오브젝트 타입이 추가될 때 테스트 확장 전략에 대한 논의도 이어가면 좋겠습니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.