### PR TITLE
Feature: 프로젝트 생성/조회/수정/삭제(CRUD) API 연동

### DIFF
--- a/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
+++ b/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import ModalOverlay from "@/components/Common/ModalOverlay";
+import ProjectNameInputModal from "@/components/DominoHUD/ProjectNameInputModal/ProjectNameInputModal";
+import useCreateProjectsQueries from "@/hooks/useCreateProjectQueries";
+import useDeleteProjectsQueries from "@/hooks/useDeleteProjectQueries";
+import useProjectsQueries from "@/hooks/useProjectsQueries";
+import useUpdateProjectQueries from "@/hooks/useUpdateProjectQueries";
+
+const ProjectListModal = ({ closeModal }) => {
+  const { projects, isLoading, isError } = useProjectsQueries();
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState(null);
+
+  const { mutate: createProject } = useCreateProjectsQueries();
+  const { mutate: deleteProject } = useDeleteProjectsQueries();
+  const { mutate: updateProject } = useUpdateProjectQueries();
+
+  const navigate = useNavigate();
+
+  return (
+    <ModalOverlay closeModal={closeModal}>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/10 backdrop-blur-sm">
+        <div className="bg-white rounded-3xl shadow-xl w-full max-w-3xl px-[40px] py-[48px] relative">
+          <div className="flex justify-between items-center mb-[32px]">
+            <h2 className="text-[20px] font-semibold text-gray-800 tracking-tight">
+              프로젝트 선택
+            </h2>
+            <button
+              onClick={closeModal}
+              className="absolute top-[24px] right-[24px] w-[40px] h-[40px] flex items-center justify-center text-[28px] text-gray-400 hover:text-gray-600 transition rounded-full hover:bg-gray-100"
+              aria-label="닫기"
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="space-y-[12px] max-h-[250px] overflow-y-auto">
+            {isLoading ?
+              <p className="text-center text-gray-400 text-base py-[40px]">로딩 중...</p>
+            : isError ?
+              <p className="text-center text-red-500 text-base py-[40px]">
+                프로젝트 목록을 불러오지 못했어요
+              </p>
+            : projects.length === 0 ?
+              <p className="text-center text-gray-400 text-base py-[40px]">
+                저장된 프로젝트가 없습니다
+              </p>
+            : projects.map((project) => (
+                <div
+                  key={project._id}
+                  className="w-full p-[16px] border border-gray-200 hover:border-yellow-500 hover:bg-yellow-50 transition rounded-xl shadow-sm"
+                >
+                  <div className="flex justify-between items-center">
+                    <button
+                      onClick={() => {
+                        closeModal();
+                        navigate(`/game/projects/${project._id}`);
+                      }}
+                      className="w-full text-left"
+                    >
+                      <span className="block text-[16px] font-medium text-gray-800">
+                        {project.title}
+                      </span>
+                      <span className="block text-[12px] text-gray-400 mt-[4px]">
+                        {project.createdAt}
+                      </span>
+                    </button>
+
+                    <div className="flex gap-[10px]">
+                      <button
+                        onClick={() => deleteProject(project._id)}
+                        className="px-[12px] py-[6px] bg-red-100 hover:bg-red-200 text-[12px] text-red-700 font-medium rounded-lg transition cursor-pointer whitespace-nowrap"
+                      >
+                        삭제
+                      </button>
+                      <button
+                        onClick={() => setEditTarget(project)}
+                        className="px-[12px] py-[6px] bg-blue-100 hover:bg-blue-200 text-[12px] text-blue-700 font-medium rounded-lg transition cursor-pointer whitespace-nowrap"
+                      >
+                        수정
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))
+            }
+          </div>
+          <div className="mt-[32px] flex justify-end">
+            <button
+              onClick={() => setIsCreateModalOpen(true)}
+              className="px-[24px] py-[10px] bg-yellow-400 hover:bg-yellow-300 text-sm font-medium text-gray-900 rounded-full shadow transition hover:scale-105"
+            >
+              새 프로젝트 만들기
+            </button>
+            {isCreateModalOpen && (
+              <ProjectNameInputModal
+                closeModal={() => setIsCreateModalOpen(false)}
+                onSubmit={(name) => createProject(name)}
+                submitLabel="생성하기"
+              />
+            )}
+            {editTarget && (
+              <ProjectNameInputModal
+                closeModal={() => setEditTarget(null)}
+                onSubmit={(newTitle) => {
+                  updateProject({ projectId: editTarget._id, title: newTitle });
+                  setEditTarget(null);
+                }}
+                defaultValue={editTarget.title}
+                submitLabel="수정하기"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+};
+
+export default ProjectListModal;

--- a/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
+++ b/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
@@ -9,7 +9,7 @@ import useProjectsQueries from "@/hooks/useProjectsQueries";
 import useUpdateProjectQueries from "@/hooks/useUpdateProjectQueries";
 
 const ProjectListModal = ({ closeModal }) => {
-  const { projects, isLoading, isError } = useProjectsQueries();
+  const { data: projects, isLoading, isError } = useProjectsQueries();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editTarget, setEditTarget] = useState(null);
 

--- a/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
+++ b/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
@@ -56,7 +56,7 @@ const ProjectListModal = ({ closeModal }) => {
                     <button
                       onClick={() => {
                         closeModal();
-                        navigate(`/game/projects/${project._id}`);
+                        navigate(`/projects/${project._id}`);
                       }}
                       className="w-full text-left"
                     >

--- a/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
+++ b/src/components/DominoHUD/ProjectListModal/ProjectListModal.jsx
@@ -19,6 +19,22 @@ const ProjectListModal = ({ closeModal }) => {
 
   const navigate = useNavigate();
 
+  const getStatus = () => {
+    if (isLoading) {
+      return { text: "로딩 중...", color: "text-gray-400" };
+    }
+
+    if (isError) {
+      return { text: "프로젝트 목록을 불러오지 못했어요", color: "text-red-500" };
+    }
+
+    if (projects.length === 0) {
+      return { text: "저장된 프로젝트가 없습니다", color: "text-gray-400" };
+    }
+  };
+
+  const status = getStatus();
+
   return (
     <ModalOverlay closeModal={closeModal}>
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/10 backdrop-blur-sm">
@@ -37,16 +53,8 @@ const ProjectListModal = ({ closeModal }) => {
           </div>
 
           <div className="space-y-[12px] max-h-[250px] overflow-y-auto">
-            {isLoading ?
-              <p className="text-center text-gray-400 text-base py-[40px]">로딩 중...</p>
-            : isError ?
-              <p className="text-center text-red-500 text-base py-[40px]">
-                프로젝트 목록을 불러오지 못했어요
-              </p>
-            : projects.length === 0 ?
-              <p className="text-center text-gray-400 text-base py-[40px]">
-                저장된 프로젝트가 없습니다
-              </p>
+            {status ?
+              <p className={`text-center text-base py-[40px] ${status.color}`}>{status.text}</p>
             : projects.map((project) => (
                 <div
                   key={project._id}

--- a/src/components/DominoHUD/ProjectNameInputModal/ProjectNameInputModal.jsx
+++ b/src/components/DominoHUD/ProjectNameInputModal/ProjectNameInputModal.jsx
@@ -1,14 +1,12 @@
 import { useState } from "react";
-
-import ModalOverlay from "@/components/Common/ModalOverlay";
+import { useId } from "react";
 
 const ProjectNameInputModal = ({ closeModal, onSubmit }) => {
   const [projectName, setProjectName] = useState("");
+  const inputId = useId();
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (!projectName.trim()) return alert("프로젝트 이름을 입력해주세요");
-
     onSubmit(projectName);
     closeModal();
   };
@@ -33,11 +31,18 @@ const ProjectNameInputModal = ({ closeModal, onSubmit }) => {
           onSubmit={handleSubmit}
           className="space-y-[8px]"
         >
-          <label className="text-[14px] font-medium text-gray-700">프로젝트 이름</label>
+          <label
+            htmlFor={inputId}
+            className="text-[14px] font-medium text-gray-700"
+          >
+            프로젝트 이름
+          </label>
           <input
+            id={inputId}
             type="text"
             value={projectName}
             onChange={(e) => setProjectName(e.target.value)}
+            required
             className="w-full px-[16px] py-[12px] border border-gray-300 rounded-xl text-[14px] focus:outline-none focus:ring-2 focus:ring-yellow-300 transition"
             placeholder="예: 도미노 시뮬레이터"
           />

--- a/src/components/DominoHUD/ProjectNameInputModal/ProjectNameInputModal.jsx
+++ b/src/components/DominoHUD/ProjectNameInputModal/ProjectNameInputModal.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+import ModalOverlay from "@/components/Common/ModalOverlay";
+
+const ProjectNameInputModal = ({ closeModal, onSubmit }) => {
+  const [projectName, setProjectName] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!projectName.trim()) return alert("프로젝트 이름을 입력해주세요");
+
+    onSubmit(projectName);
+    closeModal();
+  };
+
+  return (
+    <div className="fixed inset-0 z-100 flex items-center justify-center bg-white/10 backdrop-blur-sm">
+      <div className="bg-white rounded-3xl shadow-xl w-full max-w-xl px-[40px] py-[48px] relative">
+        <div className="flex justify-between items-center mb-[32px]">
+          <h2 className="text-[20px] font-semibold text-gray-800 tracking-tight">
+            새 프로젝트 생성
+          </h2>
+          <button
+            onClick={closeModal}
+            className="absolute top-[24px] right-[24px] w-[40px] h-[40px] flex items-center justify-center text-[28px] text-gray-400 hover:text-gray-600 transition rounded-full hover:bg-gray-100"
+            aria-label="닫기"
+          >
+            ×
+          </button>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-[8px]"
+        >
+          <label className="text-[14px] font-medium text-gray-700">프로젝트 이름</label>
+          <input
+            type="text"
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            className="w-full px-[16px] py-[12px] border border-gray-300 rounded-xl text-[14px] focus:outline-none focus:ring-2 focus:ring-yellow-300 transition"
+            placeholder="예: 도미노 시뮬레이터"
+          />
+
+          <div className="mt-[32px] flex justify-end">
+            <button
+              type="submit"
+              className="px-[24px] py-[10px] bg-yellow-400 hover:bg-yellow-300 text-sm font-medium text-gray-900 rounded-full shadow transition hover:scale-105"
+            >
+              생성하기
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectNameInputModal;

--- a/src/hooks/useCreateProjectQueries.jsx
+++ b/src/hooks/useCreateProjectQueries.jsx
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetcher from "@/services/fetcher";
+
+const createProject = (newName) => {
+  return fetcher("/projects", { method: "POST", body: { title: newName } });
+};
+
+const useProjectsQueries = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (newName) => createProject(newName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+};
+
+export default useProjectsQueries;

--- a/src/hooks/useDeleteProjectQueries.jsx
+++ b/src/hooks/useDeleteProjectQueries.jsx
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetcher from "@/services/fetcher";
+
+const deleteProject = (projectId) => {
+  return fetcher(`/projects/${projectId}`, { method: "DELETE" });
+};
+
+const useDeleteProjectsQueries = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (projectId) => deleteProject(projectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+};
+
+export default useDeleteProjectsQueries;

--- a/src/hooks/useProjectsQueries.jsx
+++ b/src/hooks/useProjectsQueries.jsx
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import fetcher from "@/services/fetcher";
+
+const useProjectsQueries = () => {
+  const {
+    data: projects = [],
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ["projects"], queryFn: () => fetcher("/projects") });
+
+  return { projects, isLoading, isError };
+};
+
+export default useProjectsQueries;

--- a/src/hooks/useProjectsQueries.jsx
+++ b/src/hooks/useProjectsQueries.jsx
@@ -3,13 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import fetcher from "@/services/fetcher";
 
 const useProjectsQueries = () => {
-  const {
-    data: projects = [],
-    isLoading,
-    isError,
-  } = useQuery({ queryKey: ["projects"], queryFn: () => fetcher("/projects") });
-
-  return { projects, isLoading, isError };
+  return useQuery({ queryKey: ["projects"], queryFn: () => fetcher("/projects") });
 };
 
 export default useProjectsQueries;

--- a/src/hooks/useRefreshAccessToken.jsx
+++ b/src/hooks/useRefreshAccessToken.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-const Game = () => {
+const useRefreshAccessToken = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -27,4 +27,4 @@ const Game = () => {
   }, [navigate]);
 };
 
-export default Game;
+export default useRefreshAccessToken;

--- a/src/hooks/useUpdateProjectQueries.jsx
+++ b/src/hooks/useUpdateProjectQueries.jsx
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetcher from "@/services/fetcher";
+
+const updateProject = ({ projectId, title }) => {
+  return fetcher(`/projects/${projectId}`, {
+    method: "PATCH",
+    body: { title: title },
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+const useUpdateProjectQueries = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ projectId, title }) => updateProject({ projectId, title }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+};
+
+export default useUpdateProjectQueries;

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+
 import { DominoCanvas } from "@/components/DominoCanvas";
 import DominoHUD from "@/components/DominoHUD/DominoHUD";
+import ProjectListModal from "@/components/DominoHUD/ProjectListModal/ProjectListModal";
 import useDominoKeyboardControls from "@/hooks/useDominoKeyboardControls";
 import useDominoSimulation from "@/hooks/useDominoSimulation";
 import useToastControls from "@/hooks/useToastControls";
@@ -10,9 +13,11 @@ const DominoScene = () => {
   const { rigidBodyRefs, readyDominoSimulation, switchToReadyMode } = useDominoSimulation();
 
   useDominoKeyboardControls(setIsGuideToastVisible);
+  const [isProjectListModal, setProjectListModal] = useState(true);
 
   return (
     <>
+      {isProjectListModal && <ProjectListModal closeModal={() => setProjectListModal(false)} />}
       <DominoHUD
         isOpenGuideToastVisible={isOpenGuideToastVisible}
         rigidBodyRefs={rigidBodyRefs}

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 
 import { DominoCanvas } from "@/components/DominoCanvas";
 import DominoHUD from "@/components/DominoHUD/DominoHUD";
@@ -8,29 +9,38 @@ import useDominoSimulation from "@/hooks/useDominoSimulation";
 import useToastControls from "@/hooks/useToastControls";
 
 const DominoScene = () => {
+  const { projectId } = useParams();
+  const [isProjectListModal, setProjectListModal] = useState(!projectId);
+
   const { isOpenGuideToastVisible, openGuideToast, closeGuideToast, setIsGuideToastVisible } =
     useToastControls();
+
   const { rigidBodyRefs, readyDominoSimulation, switchToReadyMode } = useDominoSimulation();
 
   useDominoKeyboardControls(setIsGuideToastVisible);
-  const [isProjectListModal, setProjectListModal] = useState(true);
 
   return (
     <>
       {isProjectListModal && <ProjectListModal closeModal={() => setProjectListModal(false)} />}
-      <DominoHUD
-        isOpenGuideToastVisible={isOpenGuideToastVisible}
-        rigidBodyRefs={rigidBodyRefs}
-        switchToReadyMode={switchToReadyMode}
-      />
-      <DominoCanvas
-        openGuideToast={openGuideToast}
-        closeGuideToast={closeGuideToast}
-        readyDominoSimulation={readyDominoSimulation}
-        rigidBodyRefs={rigidBodyRefs}
-        isOpenGuideToastVisible={isOpenGuideToastVisible}
-      />
+
+      {projectId && (
+        <>
+          <DominoHUD
+            isOpenGuideToastVisible={isOpenGuideToastVisible}
+            rigidBodyRefs={rigidBodyRefs}
+            switchToReadyMode={switchToReadyMode}
+          />
+          <DominoCanvas
+            openGuideToast={openGuideToast}
+            closeGuideToast={closeGuideToast}
+            readyDominoSimulation={readyDominoSimulation}
+            rigidBodyRefs={rigidBodyRefs}
+            isOpenGuideToastVisible={isOpenGuideToastVisible}
+          />
+        </>
+      )}
     </>
   );
 };
+
 export default DominoScene;

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -21,23 +21,20 @@ const OAuthCallback = () => {
           body: JSON.stringify({ code }),
         });
         const data = await response.json();
+
+        if (!response.ok) {
+          const errorMessage = data.message;
+          console.warn("로그인 실패:", errorMessage);
+          alert(errorMessage);
+          navigate("/");
+
+          return;
+        }
+
         localStorage.setItem("dominoAccessToken", data.token);
         localStorage.setItem("dominoRefreshToken", data.refreshToken);
 
-        if (!response.ok) {
-          const errorData = await response.json();
-
-          if (errorData.message?.includes("KOE320")) {
-            console.warn("만료된 인가 코드, 카카오 로그인 다시 시도");
-            window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${
-              import.meta.env.VITE_KAKAO_REST_API_KEY
-            }&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code`;
-            return;
-          }
-          throw new Error("서버 응답 실패!!!");
-        }
-
-        navigate("/game");
+        navigate("/projects");
       } catch (err) {
         console.error("로그인 실패", err);
       }

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { HTTPError } from "@/utils/HTTPError";
+
 const OAuthCallback = () => {
   const navigate = useNavigate();
 
@@ -25,10 +27,8 @@ const OAuthCallback = () => {
         if (!response.ok) {
           const errorMessage = data.message;
           console.warn("로그인 실패:", errorMessage);
-          alert(errorMessage);
           navigate("/");
-
-          return;
+          throw new HTTPError(401, data.message);
         }
 
         localStorage.setItem("dominoAccessToken", data.token);
@@ -36,7 +36,7 @@ const OAuthCallback = () => {
 
         navigate("/projects");
       } catch (err) {
-        console.error("로그인 실패", err);
+        throw new HTTPError(err.response.status, err.message);
       }
     };
 

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -14,7 +14,7 @@ const OAuthCallback = () => {
       }
 
       try {
-        const response = await fetch(`${import.meta.env.VITE_BACKEND_API}/auth/login`, {
+        const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/auth/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
@@ -22,6 +22,7 @@ const OAuthCallback = () => {
         });
         const data = await response.json();
         localStorage.setItem("dominoAccessToken", data.token);
+        localStorage.setItem("dominoRefreshToken", data.refreshToken);
 
         if (!response.ok) {
           const errorData = await response.json();

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -43,7 +43,11 @@ const OAuthCallback = () => {
     fetchAccessToken();
   }, [navigate]);
 
-  return <p>로그인 처리 중...</p>;
+  return (
+    <div className="flex items-center justify-center h-screen bg-white">
+      <div className="w-12 h-12 border-4 border-yellow-400 border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
 };
 
 export default OAuthCallback;

--- a/src/routers/routes.jsx
+++ b/src/routers/routes.jsx
@@ -1,18 +1,16 @@
 import { createBrowserRouter } from "react-router-dom";
 
 import DominoScene from "@/pages/DominoScene";
-import Game from "@/pages/Game";
 import Home from "@/pages/Home";
 import NotFound from "@/pages/NotFound";
 import OAuthCallback from "@/pages/OAuthCallback";
 
 const routes = createBrowserRouter([
   { path: "/", element: <Home /> },
-  { path: "game", element: <DominoScene /> },
-  { path: "projects/:projectId", element: <DominoScene /> },
   { path: "*", element: <NotFound /> },
   { path: "/oauth/callback", element: <OAuthCallback /> },
-  { path: "/game", element: <Game /> },
+  { path: "projects", element: <DominoScene /> },
+  { path: "projects/:projectId", element: <DominoScene /> },
 ]);
 
 export default routes;


### PR DESCRIPTION
## #️⃣ Issue Number #90

## 📝 요약(Summary)
- 백엔드에서 제공하는 프로젝트 CRUD API와 프론트엔드 로직을 연동했습니다.
- 프로젝트 생성, 목록 불러오기, 이름 수정, 삭제 기능을 정상적으로 수행할 수 있도록 구현하였습니다.
- API 요청 시 에러 핸들링도 함께 반영했습니다.

## 📸 스크린샷 

https://github.com/user-attachments/assets/f66529ad-374e-496c-a17d-da6e6fa0c52b



## 💬 공유사항 to 리뷰어
현재 리프레시 토큰은 로컬 스토리지와 쿠키 양쪽에 저장하고 있으며, 어떤 방식을 최종 적용할지는 내일 회의에서 논의 후 결정할 예정입니다. 회의 결과에 따라 하나로 통일하면 좋을 것 같습니다.

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 코드 컨벤션에 맞게 작성했습니다.