### PR TITLE
Fix: 클리어 버튼 클릭 시 서버에 도미노 삭제 요청이 전송되지 않는 현상 수정

### DIFF
--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -24,7 +24,7 @@ const DominoEntity = ({
           return (
             <RigidBody
               type={type}
-              colliders={colliders}
+              colliders={colliders ?? false}
               name={objectName}
               key={_id}
               restitution={0}

--- a/src/components/DominoHUD/DominoClearConfirmModal/DominoClearConfirmModal.jsx
+++ b/src/components/DominoHUD/DominoClearConfirmModal/DominoClearConfirmModal.jsx
@@ -1,11 +1,11 @@
 import ModalOverlay from "@/components/Common/ModalOverlay";
-import useDominoStore from "@/store/useDominoStore";
+import { useDominoMutations } from "@/hooks/Queries/useDominoMutations";
 
 const DominoClearConfirmModal = ({ closeModal }) => {
-  const clearDominos = useDominoStore((state) => state.setClearDominos);
+  const { mutate } = useDominoMutations();
 
   const handleConfirm = () => {
-    clearDominos();
+    mutate({ dominos: [] });
     closeModal();
   };
 

--- a/src/constants/objectMetaData.js
+++ b/src/constants/objectMetaData.js
@@ -75,7 +75,6 @@ export const OBJECT_METADATA = {
       thumbnail: "/images/cannon.png",
       model: "/objects/cannon.glb",
       sound: "/sounds/domino_drop.mp3",
-      colliders: false,
       type: "fixed",
     },
     pokeball: {


### PR DESCRIPTION
## #️⃣ Issue Number #102

## 📝 요약(Summary)
클리어 버튼 클릭 시 화면에서만 초기화되고 서버에는 반영되지 않던 문제를 해결했습니다.
버튼 클릭 시 서버에도 빈 도미노 배열을 저장하도록 로직을 추가해, 상태 동기화가 이루어지도록 수정했습니다.
추가로, 오브젝트 메타데이터에서 `colliders`가 `false`일 경우 문자열 `"false"`로 전달되어,
`false`인 오브젝트를 배치할 때 오류가 발생하던 문제도 함께 수정했습니다.

## 💬 공유사항 to 리뷰어
`colliders` 관련 처리 방식에 더 나은 방법이 있다면 편하게 제안해주세요!

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.