### PR TITLE
Refactor: HUD 버튼 구조 정리 및 로그아웃 버튼 컴포넌트 분리

### DIFF
--- a/src/components/DominoHUD/HUDButtonGroup/HUDButton.jsx
+++ b/src/components/DominoHUD/HUDButtonGroup/HUDButton.jsx
@@ -1,6 +1,6 @@
 import useDominoStore from "@/store/useDominoStore";
 
-const HUDButton = ({ onClick, className, children }) => {
+const HUDButton = ({ onClick, children }) => {
   const setSelectedDomino = useDominoStore((state) => state.setSelectedDomino);
 
   return (
@@ -8,7 +8,7 @@ const HUDButton = ({ onClick, className, children }) => {
       <button
         onMouseOver={() => setSelectedDomino(null)}
         onClick={onClick}
-        className={className}
+        className="w-12 h-12 flex items-center justify-center bg-white text-gray-700 rounded-full shadow-md hover:bg-gray-100 hover:shadow-lg transition-all duration-200 cursor-pointer"
       >
         {children}
       </button>

--- a/src/components/DominoHUD/HUDButtonGroup/HUDButtonGroup.jsx
+++ b/src/components/DominoHUD/HUDButtonGroup/HUDButtonGroup.jsx
@@ -1,10 +1,10 @@
-import { BiLogOut } from "react-icons/bi";
 import { FaPlay } from "react-icons/fa";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { IoSettingsSharp } from "react-icons/io5";
 import { RiResetLeftFill } from "react-icons/ri";
 
 import HUDButton from "@/components/DominoHUD/HUDButtonGroup/HUDButton";
+import HUDLogoutButton from "@/components/DominoHUD/HUDButtonGroup/HUDLogoutButton";
 import MODE from "@/constants/mode";
 import useSimulationStore from "@/store/useSimulationStore";
 
@@ -16,17 +16,15 @@ const HUDButtons = ({ onClickSetting, onClickReset, onClickPlay, onClickClear, o
       <HUDButton
         onClick={onClickSetting}
         alt="setting"
-        className="w-12 h-12 flex items-center justify-center bg-white text-gray-700 rounded-full shadow-md hover:bg-gray-100 hover:shadow-lg transition-all duration-200"
       >
-        <IoSettingsSharp className="text-3xl" />
+        <IoSettingsSharp className="text-[22px]" />
       </HUDButton>
       {simulationMode === MODE.EDIT && (
         <HUDButton
           onClick={onClickPlay}
           alt="play"
-          className="w-12 h-12 flex items-center justify-center bg-white text-gray-700 rounded-full shadow-md hover:bg-gray-100 hover:shadow-lg transition-all duration-200"
         >
-          <FaPlay className="text-2xl" />
+          <FaPlay className="text-[20px]" />
         </HUDButton>
       )}
       {simulationMode !== MODE.COUNTDOWN && (
@@ -34,28 +32,20 @@ const HUDButtons = ({ onClickSetting, onClickReset, onClickPlay, onClickClear, o
           <HUDButton
             onClick={onClickReset}
             alt="reset"
-            className="w-12 h-12 flex items-center justify-center bg-white text-gray-700 rounded-full shadow-md hover:bg-gray-100 hover:shadow-lg transition-all duration-200"
           >
-            <RiResetLeftFill className="text-3xl" />
+            <RiResetLeftFill className="text-[24px] font-bold" />
           </HUDButton>
           <HUDButton
             onClick={onClickClear}
             alt="clear"
-            className="w-12 h-12 flex items-center justify-center bg-white text-gray-700 rounded-full shadow-md hover:bg-gray-100 hover:shadow-lg transition-all duration-200"
           >
-            <FaRegTrashAlt className="text-3xl" />
+            <FaRegTrashAlt className="text-[22px]" />
           </HUDButton>
-          <div className="fixed top-4 right-6 z-50">
-            <HUDButton
-              onClick={onLogout}
-              className="flex items-center gap-2 px-4 py-2 bg-sky-300 text-gray-800 text-sm font-semibold rounded-full shadow-md hover:bg-sky-400 transition-all"
-            >
-              <BiLogOut className="text-lg" />
-              로그아웃
-            </HUDButton>
-          </div>
         </>
       )}
+      <div className="fixed top-4 right-6 z-50">
+        <HUDLogoutButton onClick={onLogout} />
+      </div>
     </div>
   );
 };

--- a/src/components/DominoHUD/HUDButtonGroup/HUDLogoutButton.jsx
+++ b/src/components/DominoHUD/HUDButtonGroup/HUDLogoutButton.jsx
@@ -1,0 +1,20 @@
+import { BiLogOut } from "react-icons/bi";
+
+import useDominoStore from "@/store/useDominoStore";
+
+const HUDLogoutButton = ({ onLogout }) => {
+  const setSelectedDomino = useDominoStore((state) => state.setSelectedDomino);
+
+  return (
+    <button
+      onMouseOver={() => setSelectedDomino(null)}
+      onClick={onLogout}
+      className="flex items-center gap-2 px-4 py-2 bg-sky-300 text-gray-800 text-sm font-semibold rounded-full shadow-md hover:bg-sky-400 transition-all cursor-pointer"
+    >
+      <BiLogOut className="text-lg" />
+      로그아웃
+    </button>
+  );
+};
+
+export default HUDLogoutButton;


### PR DESCRIPTION
## #️⃣ Issue Number #104

## 📝 요약(Summary)
HUD 영역의 버튼 구조를 정리하여 컴포넌트의 가독성과 유지보수성을 높였습니다.
특히 로그아웃 버튼은 단독 컴포넌트로 분리하여 향후 기능 확장이나 스타일 변경에 유연하게 대응할 수 있도록 개선했습니다.

## 💬 공유사항 to 리뷰어
로그아웃 버튼 분리는 우선적으로 진행했지만, 추후 다른 버튼들도 필요 시 개별 컴포넌트로 분리할 수 있을지 논의해봐도 좋을 것 같아요 😊

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.