### PR TITLE
fix: 본인이 보낸 도미노 업데이트는 무시하도록 조건 추가

### DIFF
--- a/src/store/SocketContext.jsx
+++ b/src/store/SocketContext.jsx
@@ -49,7 +49,8 @@ export const SocketProvider = ({ children }) => {
       },
     );
 
-    socket.on("domino update", ({ dominos }) => {
+    socket.on("domino update", ({ dominos, sendUser }) => {
+      if (myUserID === sendUser) return;
       setDominos(dominos);
     });
 


### PR DESCRIPTION
## #️⃣ Issue Number #130

## 📝 요약(Summary)
- 도미노 조작 시 본인이 보낸 이벤트가 다시 수신되어 `setDominos`가 중복 호출되는 문제를 해결했습니다.

변경 사항:
- `socket.on("domino update")` 내부에서 `sendUser === userID` 인 경우 early return 처리
- `userID`는 localStorage에서 가져와 비교

이 변경을 통해 동일 유저가 이벤트를 중복 처리하지 않도록 방지했습니다.

## 💬 공유사항 to 리뷰어
- 혹시 `userID`를 전역 상태로 관리하는 게 더 나을지 의견 주세요.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.