### PR TITLE
Feature: 카메라가 바닥 아래를 향하지 못하도록 각도 제한 적용

### DIFF
--- a/src/components/DominoCanvas/CameraControls/CameraControls.jsx
+++ b/src/components/DominoCanvas/CameraControls/CameraControls.jsx
@@ -83,6 +83,8 @@ const CameraControls = ({ cameraAngle }) => {
       rotateSpeed={rotationSensitivity}
       enableDamping={true}
       dampingFactor={1.25}
+      minPolarAngle={Math.PI / 6}
+      maxPolarAngle={Math.PI / 2.2}
     />
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number #143

## 📝 요약(Summary)
`OrbitControls` 설정에서 `maxPolarAngle` 값을 조정하여,
카메라가 바닥 아래를 향하지 못하도록 시야를 제한하는 기능을 적용했습니다.

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/05fa89cb-d026-4f36-9621-dd0ead3f3f6d




## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.