### PR TITLE
Refactor: Zustand persist 미들웨어 사용하여 사용자 정보 동기화

### DIFF
--- a/src/pages/LogoutCallback.jsx
+++ b/src/pages/LogoutCallback.jsx
@@ -1,13 +1,18 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
+import useUserStore from "@/store/useUserStore";
+
 const LogoutCallback = () => {
   const navigate = useNavigate();
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
 
   useEffect(() => {
     localStorage.removeItem("dominoAccessToken");
     localStorage.removeItem("dominoRefreshToken");
     localStorage.removeItem("kakaoAccessToken");
+
+    setUserInfo(null);
 
     navigate("/");
   }, [navigate]);

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
+import useUserStore from "@/store/useUserStore";
 import { HTTPError } from "@/utils/HTTPError";
 
 const OAuthCallback = () => {
+  const { setUserInfo } = useUserStore.getState();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -30,10 +32,14 @@ const OAuthCallback = () => {
           throw new HTTPError(401, data.message);
         }
 
+        setUserInfo({
+          userID: data.userID,
+          userNickname: data.userNickname,
+          isTutorialUser: data.isTutorialUser,
+        });
+
         localStorage.setItem("dominoAccessToken", data.token);
         localStorage.setItem("dominoRefreshToken", data.refreshToken);
-        localStorage.setItem("userNickname", data.userNickname);
-        localStorage.setItem("userID", data.userID);
         localStorage.setItem("kakaoAccessToken", data.kakaoAccessToken);
 
         navigate("/projects");

--- a/src/services/socket.js
+++ b/src/services/socket.js
@@ -1,7 +1,11 @@
 import { io } from "socket.io-client";
 
-const userNickname = localStorage.getItem("userNickname");
-const userID = localStorage.getItem("userID");
+import useUserStore from "@/store/useUserStore";
+
+const { userInfo } = useUserStore.getState();
+
+const userID = userInfo?.userID;
+const userNickname = userInfo?.userNickname;
 
 const socket = io(import.meta.env.VITE_API_BASE_URL, { query: { userNickname, userID } });
 

--- a/src/store/SocketContext.jsx
+++ b/src/store/SocketContext.jsx
@@ -5,6 +5,7 @@ import { useToast } from "./ToastContext";
 
 import socket from "@/services/socket";
 import useDominoStore from "@/store/useDominoStore";
+import useUserStore from "@/store/useUserStore";
 
 export const SocketContext = createContext(null);
 
@@ -13,7 +14,9 @@ export const SocketProvider = ({ children }) => {
   const { setDominos } = useDominoStore();
   const [otherCursors, setOtherCursors] = useState({});
   const { showToast } = useToast();
-  const myUserID = localStorage.getItem("userID");
+  const { userInfo } = useUserStore.getState();
+
+  const myUserID = userInfo?.userID;
   const navigate = useNavigate();
 
   const removeCursor = (userID) => {

--- a/src/store/useUserStore.jsx
+++ b/src/store/useUserStore.jsx
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const useUserStore = create(
+  persist(
+    (set) => ({
+      userInfo: null,
+      setUserInfo: (info) => set({ userInfo: info }),
+      setIsTutorialUser: (value) =>
+        set((state) => ({ userInfo: { ...state.userInfo, isTutorialUser: value } })),
+    }),
+    { name: "dominoUserStorage", partialize: (state) => ({ userInfo: state.userInfo }) },
+  ),
+);
+
+export default useUserStore;


### PR DESCRIPTION
## #️⃣ Issue Number #145

## 📝 요약(Summary)
유저 정보를 DB에서 받아온 뒤, Zustand의 persist 미들웨어를 활용하여 상태를
로컬스토리지에 자동으로 저장하고 유지하도록 구조를 리팩토링했습니다.

이로써 새로고침 이후에도 유저 정보를 안정적으로 유지할 수 있게 되었으며,
기존에 `localStorage.getItem(...)`으로 직접 접근하던 방식 대신, 
전역 상태를 통해 일관된 방식으로 유저 정보를 사용할 수 있는 구조로 정비했습니다.

## 💬 공유사항 to 리뷰어
기존 `localStorage` 접근을 제거한 부분에서 누락된 곳이 있는지 확인 부탁드립니다.

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 코드 컨벤션에 맞게 작성했습니다.