### PR TITLE
Feature: 튜토리얼 상태 업데이트 API 연동

### DIFF
--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 import ModalLayer from "@/components/Common/ModalLayer";
 import {
@@ -10,9 +10,11 @@ import {
   Tutorial,
 } from "@/components/DominoHUD";
 import ProjectListModal from "@/components/DominoHUD/ProjectListModal/ProjectListModal";
+import { useUpdateTutorialStatus } from "@/hooks/Queries/useUpdateTutorialStatus";
 import useDominoReset from "@/hooks/useDominoReset";
 import fetcher from "@/services/fetcher";
 import useDominoStore from "@/store/useDominoStore";
+import useUserStore from "@/store/useUserStore";
 import { HTTPError } from "@/utils/HTTPError";
 
 const DominoHUD = ({ rigidBodyRefs, isOpenGuideToastVisible }) => {
@@ -20,13 +22,8 @@ const DominoHUD = ({ rigidBodyRefs, isOpenGuideToastVisible }) => {
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false);
   const [isClearConfirmModalOpen, setClearConfirmModalOpen] = useState(false);
   const [isProjectListModal, setProjectListModal] = useState(false);
-  const [isTutorialUser, setIsTutorialUser] = useState(() => {
-    return localStorage.getItem("isTutorialUser") === "true";
-  });
-
-  useEffect(() => {
-    localStorage.setItem("isTutorialUser", isTutorialUser.toString());
-  }, [isTutorialUser]);
+  const isTutorialUser = useUserStore((state) => state.userInfo?.isTutorialUser);
+  const { mutate } = useUpdateTutorialStatus();
 
   const { resetDominoSimulation } = useDominoReset(rigidBodyRefs);
 
@@ -89,7 +86,7 @@ const DominoHUD = ({ rigidBodyRefs, isOpenGuideToastVisible }) => {
       />
       <SidePanel />
       <ModalLayer modals={modals} />
-      {isTutorialUser && <Tutorial onTutorialEnd={() => setIsTutorialUser(false)} />}
+      {isTutorialUser && <Tutorial onTutorialEnd={() => mutate({ isTutorialUser: false })} />}
     </>
   );
 };

--- a/src/hooks/Queries/useUpdateTutorialStatus.jsx
+++ b/src/hooks/Queries/useUpdateTutorialStatus.jsx
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import fetcher from "@/services/fetcher";
-import { useTutorialStore } from "@/store/useTutorialStore";
+import useUserStore from "@/store/useUserStore";
 
 export const useUpdateTutorialStatus = () => {
   const queryClient = useQueryClient();
-  const setIsTutorialUser = useTutorialStore((state) => state.setIsTutorialUser);
+  const setIsTutorialUser = useUserStore((state) => state.setIsTutorialUser);
 
   return useMutation({
     mutationFn: ({ isTutorialUser }) =>

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -41,7 +41,6 @@ const OAuthCallback = () => {
         localStorage.setItem("dominoAccessToken", data.token);
         localStorage.setItem("dominoRefreshToken", data.refreshToken);
         localStorage.setItem("kakaoAccessToken", data.kakaoAccessToken);
-        localStorage.setItem("isTutorialUser", true);
 
         navigate("/projects");
       } catch (err) {


### PR DESCRIPTION
## #️⃣ Issue Number #148

## 📝 요약(Summary)
튜토리얼 완료 여부를 서버에 반영할 수 있도록
튜토리얼 상태 수정 API(/auth/me/tutorial)와 클라이언트 상태 관리 로직을 연동하였습니다.
이를 통해 사용자의 튜토리얼 상태가 서버와 클라이언트 간 일관되게 유지되며,
새로고침 이후에도 정확한 상태를 반영할 수 있게 됩니다.

## 💬 공유사항 to 리뷰어
Zustand 상태 업데이트 방식이나 네이밍 관련해서도 개선 의견 있으시면 알려주세요!

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.