### PR TITLE
Fix: 튜토리얼 종료 후에도 캐논 트리거 영역이 씬에 남아있는 현상 수정

### DIFF
--- a/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
+++ b/src/components/DominoCanvas/DominoEntity/DominoEntity.jsx
@@ -5,15 +5,17 @@ import DominoVisualUnit from "@/components/DominoCanvas/DominoEntity/DominoVisua
 import TutorialStepHandler from "@/components/DominoCanvas/DominoEntity/TutorialStepHandler/TutorialStepHandler";
 import { useDominos } from "@/hooks/Queries/useDominos";
 import useDominoStore from "@/store/useDominoStore";
+import useUserStore from "@/store/useUserStore";
 import { getCollisionGroupMask } from "@/utils/collisionGroups";
 
 const DominoEntity = ({ openGuideToast, closeGuideToast, rigidBodyRefs }) => {
   useDominos();
   const dominos = useDominoStore((state) => state.dominos);
+  const isTutorialUser = useUserStore((state) => state.userInfo?.isTutorialUser);
 
   return (
     <>
-      <TutorialStepHandler />
+      {isTutorialUser && <TutorialStepHandler />}
       {dominos.length
         && dominos.map((domino, index) => {
           const { position, rotation, color, opacity, _id, objectInfo } = domino;


### PR DESCRIPTION
## #️⃣ Issue Number #152

## 📝 요약(Summary)
튜토리얼이 종료된 이후에도 Cannon 트리거 영역이 씬에 계속 남아있는 문제가 있었습니다.
`<TutorialStepHandler />` 컴포넌트를 `isTutorialUser` 상태 값에 따라 조건부 렌더링하도록 변경하여,
튜토리얼이 끝나면 해당 UI 요소도 함께 제거되도록 수정했습니다.

## 💬 공유사항 to 리뷰어
혹시 더 나은 위치에서 조건부 렌더링하는 방식에 대한 의견이 있다면 제안 부탁드립니다! 😊

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.