### PR TITLE
Fix: 리셋 버튼 클릭시 도미노가 정상적으로 초기화되지 않는 현상 수정

### DIFF
--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -18,7 +18,7 @@ import useUIStateStore from "@/store/useUIStateStore";
 import useUserStore from "@/store/useUserStore";
 import { HTTPError } from "@/utils/HTTPError";
 
-const DominoHUD = ({ rigidBodyRefs, isOpenGuideToastVisible }) => {
+const DominoHUD = ({ isOpenGuideToastVisible }) => {
   const clearDominos = useDominoStore((state) => state.setClearDominos);
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false);
   const [isClearConfirmModalOpen, setClearConfirmModalOpen] = useState(false);
@@ -28,7 +28,7 @@ const DominoHUD = ({ rigidBodyRefs, isOpenGuideToastVisible }) => {
 
   const { mutate } = useUpdateTutorialStatus();
 
-  const { resetDominoSimulation } = useDominoReset(rigidBodyRefs);
+  const { resetDominoSimulation } = useDominoReset();
 
   useEffect(() => {
     if (isSettingModalOpen || isClearConfirmModalOpen || isProjectListModal) {

--- a/src/hooks/useDominoReset.jsx
+++ b/src/hooks/useDominoReset.jsx
@@ -1,44 +1,28 @@
 import { useEffect } from "react";
-import * as THREE from "three";
 
 import { OBJECT_GROUP_NAMES } from "@/constants/objectMetaData.js";
 import { useDominoMutations } from "@/hooks/Queries/useDominoMutations";
 import { useSocket } from "@/store/SocketContext";
 import useDominoStore from "@/store/useDominoStore";
 
-const useDominoReset = (rigidBodyRefs) => {
+const useDominoReset = () => {
   const dominos = useDominoStore((state) => state.dominos);
   const { socket, projectId } = useSocket();
   const { mutate } = useDominoMutations();
 
   const resetAllDominoes = () => {
-    const filteredDominos = dominos.filter(
-      (domino) => domino.objectInfo?.groupName === OBJECT_GROUP_NAMES.STATIC,
-    );
+    const filteredDominos = dominos
+      .filter((domino) => domino.objectInfo?.groupName === OBJECT_GROUP_NAMES.STATIC)
+      .map((domino) => {
+        const { _id, ...rest } = domino;
+        return rest;
+      });
 
     mutate({ dominos: filteredDominos });
-
-    requestAnimationFrame(() => {
-      filteredDominos.forEach((domino, index) => {
-        const rigidBody = rigidBodyRefs.current[index];
-        if (!rigidBody) return;
-
-        const { position, rotation } = domino;
-
-        const eulerRotation = new THREE.Euler(rotation[0], rotation[1], rotation[2]);
-        const rotationQuaternion = new THREE.Quaternion().setFromEuler(eulerRotation);
-
-        rigidBody.setTranslation({ x: position[0], y: position[1], z: position[2] }, true);
-        rigidBody.setRotation(rotationQuaternion, true);
-        rigidBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
-        rigidBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
-        rigidBody.sleep();
-      });
-    });
   };
 
   const resetDominoSimulation = () => {
-    if (!rigidBodyRefs.current.length > 0) return;
+    if (!dominos.length) return;
     resetAllDominoes();
 
     socket.emit("reset domino", { projectId });
@@ -49,8 +33,13 @@ const useDominoReset = (rigidBodyRefs) => {
       resetAllDominoes();
     });
 
+    socket.on("user joined", () => {
+      resetAllDominoes();
+    });
+
     return () => {
       socket.off("reset domino");
+      socket.off("user joined");
     };
   }, []);
 

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -34,12 +34,7 @@ const DominoScene = () => {
   return (
     <SocketProvider>
       <DominoKeyboardHandler setIsGuideToastVisible={setIsGuideToastVisible}>
-        {isCanvasReady && (
-          <DominoHUD
-            isOpenGuideToastVisible={isOpenGuideToastVisible}
-            rigidBodyRefs={rigidBodyRefs}
-          />
-        )}
+        {isCanvasReady && <DominoHUD isOpenGuideToastVisible={isOpenGuideToastVisible} />}
         <DominoCanvas
           openGuideToast={openGuideToast}
           closeGuideToast={closeGuideToast}


### PR DESCRIPTION
## #️⃣ Issue Number #155

## 📝 요약(Summary)
Reset 버튼 클릭 시 도미노 리셋이 정상적으로 동작하도록 로직을 개선했습니다.
기존에는 도미노의 위치만 초기화되었으나, 상태가 불안정하게 유지되거나 일부 도미노가 사라지는 이슈가 간헐적으로 발생했습니다.
이에 _id를 제거한 새 배열을 insert 방식으로 재등록하여 리렌더링을 유도하고, 보다 안정적으로 리셋되도록 처리했습니다.

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/a3654b79-177a-4e4b-a036-b5a0395c60fd

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.