### PR TITLE
Feature: 도미노 업적 달성 초기 세팅 및 업적 내용 구축

### DIFF
--- a/src/achievments/CheckDominoAchievement.jsx
+++ b/src/achievments/CheckDominoAchievement.jsx
@@ -1,0 +1,77 @@
+import useAchievementStore from "@/store/useAchievementStore";
+
+export const CheckFirstDominoAchievement = async ({ dominoCount, userId, showToast }) => {
+  const { achievements, setAchievement } = useAchievementStore.getState();
+
+  if (dominoCount >= 1 && !achievements["first_domino"]) {
+    setAchievement("first_domino");
+    showToast({ message: "🎉 도전과제 달성: 첫 도미노!", placement: "center" });
+
+    try {
+      await fetch("http://localhost:3000/achievements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, name: "first_domino" }),
+      });
+    } catch (err) {
+      console.error("업적 저장 실패:", err);
+    }
+  }
+};
+
+export const CheckHundredDominoAchievement = async ({ dominoCount, userId, showToast }) => {
+  const { achievements, setAchievement } = useAchievementStore.getState();
+
+  if (dominoCount >= 10 && !achievements["hundred_domino"]) {
+    setAchievement("hundred_domino");
+    showToast({ message: "🎉 도전과제 달성! 100번째 도미노까지 놓았어요!", placement: "center" });
+
+    try {
+      await fetch("http://localhost:3000/achievements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, name: "hundred_domino" }),
+      });
+    } catch (err) {
+      console.error("업적 저장 실패:", err);
+    }
+  }
+};
+
+export const CheckChangeDominoColorAchievement = async ({ userId, showToast }) => {
+  const { achievements, setAchievement } = useAchievementStore.getState();
+
+  if (!achievements["color_used"]) {
+    setAchievement("color_used");
+    showToast({ message: "🎉 도전과제 달성! 도미노 색깔을 바꿔봤어요!", placement: "center" });
+
+    try {
+      await fetch("http://localhost:3000/achievements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, name: "color_used" }),
+      });
+    } catch (err) {
+      console.error("업적 저장 실패:", err);
+    }
+  }
+};
+
+export const CheckFirstDominoFallAchievement = async ({ userId, showToast }) => {
+  const { achievements, setAchievement } = useAchievementStore.getState();
+
+  if (achievements["all_domino_fallen"]) {
+    setAchievement("all_domino_fallen");
+    showToast({ message: "🎉 도전과제 달성! 모든 도미노를 쓰러뜨렸습니다!", placement: "center" });
+
+    try {
+      await fetch("http://localhost:3000/achievements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, name: "all_domino_fallen" }),
+      });
+    } catch (err) {
+      console.error("업적 저장 실패:", err);
+    }
+  }
+};

--- a/src/components/AchievementPanel.jsx
+++ b/src/components/AchievementPanel.jsx
@@ -1,0 +1,62 @@
+import useAchievementStore from "@/store/useAchievementStore";
+
+const AchievementPanel = () => {
+  const { achievements } = useAchievementStore();
+  const allAchievements = [
+    { name: "first_domino", title: "첫 도미노!", description: "도미노를 하나라도 놓기" },
+    { name: "hundred_domino", title: "열정의 100개", description: "도미노를 100개 놓기" },
+    { name: "color_used", title: "색감 장인", description: "색상을 바꿔서 도미노 배치하기" },
+    { name: "undo_used", title: "실수는 누구에게나", description: "Undo 버튼 1회 사용" },
+    { name: "reset_used", title: "처음부터 다시 시작", description: "Reset 버튼 1회 사용" },
+    { name: "hide_used", title: "호그와트 신입생", description: "도미노 숨기기 기능 사용" },
+    {
+      name: "invited_friend",
+      title: "친구와 함게 도미노",
+      description: "초대코드를 통해 입장한 유저 1명 이상",
+    },
+    {
+      name: "all_domino_fallen",
+      title: "완벽한 연쇄",
+      description: "배치한 모든 도미노를 쓰러뜨리는 데 성공",
+    },
+  ];
+
+  const total = allAchievements.length;
+  const achieved = allAchievements.filter((a) => achievements[a.name]?.achieved).length;
+  const percent = Math.round((achieved / total) * 100);
+
+  return (
+    <div className="fixed top-20 right-8 w-80 bg-white p-4 rounded-xl shadow-lg z-50">
+      <h2 className="text-xl font-bold mb-4">🏆 업적 달성률: {percent}%</h2>
+      <div className="w-full h-2 bg-gray-200 rounded-full mb-4">
+        <div
+          className="h-full bg-yellow-500 rounded-full"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <ul className="space-y-2 max-h-64 overflow-y-auto pr-2">
+        {allAchievements.map((achieve) => {
+          const isAchieved = achievements[achieve.name]?.achieved;
+          return (
+            <li
+              key={achieve.name}
+              className="flex justify-between items-center"
+            >
+              <div>
+                <div className="font-semibold">{achieve.title}</div>
+                <div className="text-sm text-gray-500">{achieve.description}</div>
+              </div>
+              <div className="text-right text-sm">
+                {isAchieved ?
+                  <span className="text-green-600">달성 ✅</span>
+                : <span className="text-gray-400">미달성 ❌</span>}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default AchievementPanel;

--- a/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
+++ b/src/components/DominoCanvas/CursorFollowerObject/CursorFollowerObject.jsx
@@ -2,9 +2,12 @@ import { useFrame, useThree } from "@react-three/fiber";
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
+import { CheckFirstDominoAchievement } from "@/achievments/CheckDominoAchievement";
+import { CheckHundredDominoAchievement } from "@/achievments/CheckDominoAchievement";
 import { ObjectRenderer } from "@/components/DominoCanvas";
 import { useDominoMutations } from "@/hooks/Queries/useDominoMutations";
 import { useSocket } from "@/store/SocketContext";
+import { useToast } from "@/store/ToastContext";
 import useDominoStore from "@/store/useDominoStore";
 import useSettingStore from "@/store/useSettingStore";
 import AudioController from "@/utils/AudioController";
@@ -34,6 +37,9 @@ const CursorFollowerObject = () => {
   const { projectId, socket } = useSocket();
   const { mutate } = useDominoMutations();
 
+  const { showToast } = useToast();
+  const userId = localStorage.getItem("userID");
+
   const playDominoDropSound = () => {
     audioController.current.play(selectedDomino.sound);
   };
@@ -59,6 +65,9 @@ const CursorFollowerObject = () => {
     mutate({ dominos: updatedDomino });
     socket.emit("update domino", { projectId, dominos: updatedDomino });
     playDominoDropSound();
+
+    CheckFirstDominoAchievement({ dominoCount: updatedDomino.length, userId, showToast });
+    CheckHundredDominoAchievement({ dominoCount: updatedDomino.length, userId, showToast });
   };
 
   useFrame(() => {

--- a/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
+++ b/src/components/DominoHUD/SidePanel/DominoColorPalette.jsx
@@ -1,3 +1,5 @@
+import { CheckChangeDominoColorAchievement } from "@/achievments/CheckDominoAchievement";
+import { useToast } from "@/store/ToastContext";
 import useDominoStore from "@/store/useDominoStore";
 
 const COLORS = [
@@ -16,7 +18,11 @@ export default function DominoColorPalette() {
   const selectedColor = useDominoStore((state) => state.selectedColor);
   const setSelectedColor = useDominoStore((state) => state.setSelectedColor);
 
+  const { showToast } = useToast();
+  const userId = localStorage.getItem("userID");
+
   const handleSelect = (color) => {
+    CheckChangeDominoColorAchievement({ userId, showToast });
     setSelectedColor(color);
   };
 

--- a/src/hooks/useInitAchievements.jsx
+++ b/src/hooks/useInitAchievements.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+import useAchievementStore from "@/store/useAchievementStore";
+
+const useInitAchievements = () => {
+  const loadAchievements = useAchievementStore((state) => state.loadAchievements);
+  const userId = localStorage.getItem("userID");
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const fetchAchievements = async () => {
+      try {
+        const res = await fetch(`http://localhost:3000/achievements/${userId}`);
+        const data = await res.json();
+        loadAchievements(data);
+      } catch (err) {
+        console.error("업적 불러오기 실패", err);
+      }
+    };
+
+    fetchAchievements();
+  }, [userId]);
+};
+
+export default useInitAchievements;

--- a/src/hooks/useStrictNavigationBlock.jsx
+++ b/src/hooks/useStrictNavigationBlock.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+export const useStrictNavigationBlock = () => {
+  useEffect(() => {
+    const blockBack = () => {
+      window.history.pushState(null, "정말 뒤로 가기겠습니까?", window.location.href);
+    };
+
+    blockBack();
+    window.addEventListener("popstate", blockBack);
+
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = "정말 새로고침 하시겠습니까?";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("popstate", blockBack);
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+};

--- a/src/pages/DominoScene.jsx
+++ b/src/pages/DominoScene.jsx
@@ -4,6 +4,8 @@ import DominoKeyboardHandler from "@/components/Common/DominoKeyboardHandler";
 import { DominoCanvas } from "@/components/DominoCanvas";
 import DominoHUD from "@/components/DominoHUD/DominoHUD";
 import useGlbPreloader from "@/hooks/useGlbloader";
+import useInitAchievements from "@/hooks/useInitAchievements";
+import { useStrictNavigationBlock } from "@/hooks/useStrictNavigationBlock";
 import useToastControls from "@/hooks/useToastControls";
 import { SocketProvider } from "@/store/SocketContext";
 import useUIStateStore from "@/store/useUIStateStore";
@@ -30,6 +32,8 @@ const DominoScene = () => {
   const isCanvasReady = useUIStateStore((state) => state.isCanvasReady);
 
   useGlbPreloader(MODEL_PATHS);
+  useStrictNavigationBlock();
+  useInitAchievements();
 
   return (
     <SocketProvider>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,9 +2,12 @@ import { useParams, useLocation } from "react-router-dom";
 import { useState } from "react";
 
 import ProjectListModal from "@/components/DominoHUD/ProjectListModal/ProjectListModal";
+import AchievementPanel from "@/components/AchievementPanel";
 import { SocketProvider } from "@/store/SocketContext";
 
 import { RiKakaoTalkFill } from "react-icons/ri";
+
+import useInitAchievements from "@/hooks/useInitAchievements";
 
 import logo from "/images/logo.png";
 
@@ -13,6 +16,9 @@ const Home = () => {
   const location = useLocation();
   const hasProjectPath = location.pathname === "/projects";
   const [isProjectListModal, setProjectListModal] = useState(hasProjectPath && !projectId);
+  const [isAchievementPanelOpen, setIsAchievementPanelOpen] = useState(false);
+
+  useInitAchievements();
 
   const handleLogin = () => {
     window.location.href = kakaoURL;
@@ -30,6 +36,13 @@ const Home = () => {
               draggable="false"
             />
           </h1>
+          <button
+            onClick={() => setIsAchievementPanelOpen((prev) => !prev)}
+            className="absolute top-6 right-6 bg-white/80 hover:bg-white px-4 py-2 rounded-lg text-sm shadow-md transition duration-200 z-50"
+          >
+            🏆 업적 보기
+          </button>
+          {isAchievementPanelOpen && <AchievementPanel />}
           <div className="flex items-center justify-center h-screen">
             <div className="mt-[60vh]">
               <button

--- a/src/store/useAchievementStore.jsx
+++ b/src/store/useAchievementStore.jsx
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+const useAchievementStore = create((set) => ({
+  achievements: {},
+
+  setAchievement: (name) =>
+    set((state) => ({
+      achievements: {
+        ...state.achievements,
+        [name]: { achieved: true, date: new Date().toISOString() },
+      },
+    })),
+  loadAchievements: (achievementList) =>
+    set(() => {
+      const newAchievements = {};
+      achievementList.forEach((a) => {
+        newAchievements[a.name] = { achieved: true, date: a.date };
+      });
+      return { achievements: newAchievements };
+    }),
+}));
+
+export default useAchievementStore;


### PR DESCRIPTION
## #️⃣ Issue Number
#157 

## 📝 요약(Summary)
- 업적 기능의 초기 구조를 구현하였습니다.
- 서버에서는 MongoDB 기반의 업적 저장/조회 API (POST /achievements, GET /achievements/:userId)를 제공하며,
클라이언트에서는 zustand를 활용해 업적 상태를 관리합니다.
- 첫 도미노 배치 업적(first_domino)을 기준으로 클라이언트와 서버 간 업적 동기화 흐름을 구현했습니다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/1ff29baf-62e2-4841-9436-229d5b7b9aee)


## 💬 공유사항 to 리뷰어
- 현재는 인증 없이 userId만으로 업적을 저장하고 있어, 추후 JWT 연동이 필요합니다.
- zustand에 저장된 업적과 DB 응답 구조 간 일관성을 유지하도록 key 네이밍을 맞췄습니다.
- 기타 성능, 구조, 네이밍 관련하여 개선점이 있다면 자유롭게 피드백 부탁드립니다.


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.