### PR TITLE
Fix: 리셋 시 도미노가 상대방에게 삭제되거나 중복 생성되는 현상 수정

### DIFF
--- a/src/components/DominoHUD/DominoHUD.jsx
+++ b/src/components/DominoHUD/DominoHUD.jsx
@@ -28,7 +28,7 @@ const DominoHUD = ({ isOpenGuideToastVisible }) => {
 
   const { mutate } = useUpdateTutorialStatus();
 
-  const { resetDominoSimulation } = useDominoReset();
+  const { emitDominoReset } = useDominoReset();
 
   useEffect(() => {
     if (isSettingModalOpen || isClearConfirmModalOpen || isProjectListModal) {
@@ -89,7 +89,7 @@ const DominoHUD = ({ isOpenGuideToastVisible }) => {
     <>
       <HUDButtonGroup
         onClickSetting={() => setIsSettingModalOpen(true)}
-        onClickReset={resetDominoSimulation}
+        onClickReset={emitDominoReset}
         onClickClear={() => setClearConfirmModalOpen(true)}
         onLogout={handleLogout}
         openProjectModal={() => setProjectListModal(true)}

--- a/src/hooks/Queries/useDominoOverwrite.jsx
+++ b/src/hooks/Queries/useDominoOverwrite.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+
+import fetcher from "@/services/fetcher";
+import useDominoStore from "@/store/useDominoStore";
+
+export const useDominoOverwrite = () => {
+  const { projectId } = useParams();
+  const setDominos = useDominoStore((state) => state.setDominos);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ dominos }) =>
+      fetcher(`/dominos/${projectId}/overwrite`, { method: "POST", body: { dominos } }),
+    onSuccess: (newDominos) => {
+      setDominos(newDominos);
+    },
+    onError: () => {
+      queryClient.refetchQueries(["dominos", projectId]);
+    },
+  });
+};

--- a/src/hooks/useDominoReset.jsx
+++ b/src/hooks/useDominoReset.jsx
@@ -1,16 +1,16 @@
 import { useEffect } from "react";
 
 import { OBJECT_GROUP_NAMES } from "@/constants/objectMetaData.js";
-import { useDominoMutations } from "@/hooks/Queries/useDominoMutations";
+import { useDominoOverwrite } from "@/hooks/Queries/useDominoOverwrite";
 import { useSocket } from "@/store/SocketContext";
 import useDominoStore from "@/store/useDominoStore";
 
 const useDominoReset = () => {
   const dominos = useDominoStore((state) => state.dominos);
   const { socket, projectId } = useSocket();
-  const { mutate } = useDominoMutations();
+  const { mutate } = useDominoOverwrite();
 
-  const resetAllDominoes = () => {
+  const emitDominoReset = () => {
     const filteredDominos = dominos
       .filter((domino) => domino.objectInfo?.groupName === OBJECT_GROUP_NAMES.STATIC)
       .map((domino) => {
@@ -18,23 +18,16 @@ const useDominoReset = () => {
         return rest;
       });
 
-    mutate({ dominos: filteredDominos });
-  };
-
-  const resetDominoSimulation = () => {
-    if (!dominos.length) return;
-    resetAllDominoes();
-
-    socket.emit("reset domino", { projectId });
+    socket.emit("reset domino", { projectId, dominos: filteredDominos });
   };
 
   useEffect(() => {
-    socket.on("reset domino", () => {
-      resetAllDominoes();
+    socket.on("reset domino", ({ dominos }) => {
+      mutate({ dominos });
     });
 
     socket.on("user joined", () => {
-      resetAllDominoes();
+      emitDominoReset();
     });
 
     return () => {
@@ -43,7 +36,7 @@ const useDominoReset = () => {
     };
   }, []);
 
-  return { resetDominoSimulation };
+  return { emitDominoReset };
 };
 
 export default useDominoReset;


### PR DESCRIPTION
## #️⃣ Issue Number #162

## 📝 요약(Summary)
도미노 리셋 시 소켓을 통해 기준 상태를 함께 전달하고, 모든 클라이언트가 해당 상태로 일관되게 덮어쓰도록 로직을 개선했습니다.
기존에는 리셋 이벤트만 전파하고 클라이언트마다 `dominos` 상태를 개별적으로 `mutate`하는 방식이었기 때문에, 
도미노가 두 배로 생성되거나 사라지는 등의 동기화 오류가 발생했습니다.

이 문제를 해결하기 위해 새로운 커스텀 훅인 `useDominoOverwrite`를 도입하여, 
받은 배열을 그대로 `setDominos` 하는 방식으로 상태를 overwrite합니다.


## 💬 공유사항 to 리뷰어
리셋 이후의 상태가 제대로 overwrite되는지, 테스트 환경에서 확인 부탁드려요

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.