### PR TITLE
Fix: 서버 기반 도미노 전환 후 튜토리얼에서 도미노 감지 및 자동 배치 기능 동작하지 않는 현상 수정

### DIFF
--- a/src/components/DominoCanvas/DominoEntity/TutorialStepHandler/CannonAutoPlacer/CannonAutoPlacer.jsx
+++ b/src/components/DominoCanvas/DominoEntity/TutorialStepHandler/CannonAutoPlacer/CannonAutoPlacer.jsx
@@ -1,10 +1,11 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 import Cannon from "@/components/DominoCanvas/DominoEntity/DominoVisualUnit/Cannon/Cannon";
 import { OBJECT_METADATA, OBJECT_GROUP_NAMES } from "@/constants/objectMetaData";
+import { useDominoMutations } from "@/hooks/Queries/useDominoMutations";
 import useTutorialTracker from "@/hooks/useTutorialTracker";
 import { useSocket } from "@/store/SocketContext";
-import useDominoStore from "@/store/useDominoStore";
 import { useTutorialStore } from "@/store/useTutorialStore";
 
 const cannonMetadata = OBJECT_METADATA[OBJECT_GROUP_NAMES.DYNAMIC].cannon;
@@ -15,10 +16,12 @@ const TRIGGER_OFFSET = [0, 0, -1.2];
 const TRIGGER_SIZE = [0.3, 32, 32];
 
 const CannonAutoPlacer = () => {
-  const dominos = useDominoStore((state) => state.dominos);
-  const setDominos = useDominoStore((state) => state.setDominos);
+  const queryClient = useQueryClient();
+  const { projectId } = useSocket();
+  const dominos = queryClient.getQueryData(["dominos", projectId]);
+
+  const { mutate } = useDominoMutations();
   const { tracker } = useTutorialStore();
-  const { projectId, socket } = useSocket();
 
   const [hasTriggered, setHasTriggered] = useState(false);
 
@@ -39,8 +42,7 @@ const CannonAutoPlacer = () => {
     };
 
     const updatedDominos = [...dominos, newCannon];
-    setDominos(updatedDominos);
-    socket.emit("update domino", { projectId, dominos: updatedDominos });
+    mutate({ dominos: updatedDominos });
   }, [tracker.placedDominoForKnock]);
 
   return (

--- a/src/components/DominoCanvas/DominoEntity/TutorialStepHandler/TutorialTargetPlace/TutorialTargetPlace.jsx
+++ b/src/components/DominoCanvas/DominoEntity/TutorialStepHandler/TutorialTargetPlace/TutorialTargetPlace.jsx
@@ -1,11 +1,14 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
 import TargetPlaceholder from "@/components/DominoCanvas/DominoEntity/TutorialStepHandler/TutorialTargetPlace/TargetPlaceHolder/TargetPlaceHolder";
 import useTutorialTracker from "@/hooks/useTutorialTracker";
-import useDominoStore from "@/store/useDominoStore";
 
 const TutorialTargetPlace = ({ positions }) => {
-  const dominos = useDominoStore((state) => state.dominos);
+  const { projectId } = useParams();
+  const queryClient = useQueryClient();
+  const dominos = queryClient.getQueryData(["dominos", projectId]);
   const [completed, setCompleted] = useState(Array(positions.length).fill(false));
 
   const isDominoPlacedNearTarget = (dominoPosition, targetPosition) => {


### PR DESCRIPTION
## #️⃣ Issue Number #175

## 📝 요약(Summary)
도미노 상태를 서버 기반으로 전환하면서 기존에 클라이언트 상태를 참조하던
튜토리얼 로직 일부가 정상적으로 동작하지 않는 문제가 발생했습니다.
이 PR에서는 도미노 가이드 위치를 인식하지 못하거나,
대포가 자동으로 배치되지 않는 버그를 수정하여 튜토리얼 전반의 흐름이 다시 정상적으로 작동하도록 반영했습니다.

## 💬 공유사항 to 리뷰어
튜토리얼의 각 단계에서 조건이 제대로 작동하는지, 도미노와 대포가 정확히 인식되고 반응하는지 확인 부탁드립니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.